### PR TITLE
fix: update UE EngineAssociation 5.6 + safer TCP recv buffer

### DIFF
--- a/MCPGameProject/MCPGameProject.uproject
+++ b/MCPGameProject/MCPGameProject.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "5.5",
+	"EngineAssociation": "5.6",
 	"Category": "",
 	"Description": "",
 	"Modules": [

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/MCPServerRunnable.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/MCPServerRunnable.cpp
@@ -12,7 +12,10 @@
 #include "HAL/PlatformTime.h"
 
 // Buffer size for receiving data
-const int32 BufferSize = 8192;
+namespace
+{
+    constexpr int32 MCPReceiveBufferSize = 8192;
+}
 
 FMCPServerRunnable::FMCPServerRunnable(UUnrealMCPBridge* InBridge, TSharedPtr<FSocket> InListenerSocket)
     : Bridge(InBridge)
@@ -56,11 +59,11 @@ uint32 FMCPServerRunnable::Run()
                 ClientSocket->SetSendBufferSize(SocketBufferSize, SocketBufferSize);
                 ClientSocket->SetReceiveBufferSize(SocketBufferSize, SocketBufferSize);
                 
-                uint8 Buffer[8192];
+                uint8 Buffer[MCPReceiveBufferSize + 1];
                 while (bRunning)
                 {
                     int32 BytesRead = 0;
-                    if (ClientSocket->Recv(Buffer, sizeof(Buffer), BytesRead))
+                    if (ClientSocket->Recv(Buffer, MCPReceiveBufferSize, BytesRead))
                     {
                         if (BytesRead == 0)
                         {
@@ -180,7 +183,7 @@ void FMCPServerRunnable::HandleClientConnection(TSharedPtr<FSocket> InClientSock
     
     // Properly read full message with timeout
     const int32 MaxBufferSize = 4096;
-    uint8 Buffer[MaxBufferSize];
+    uint8 Buffer[MaxBufferSize + 1];
     FString MessageBuffer;
     
     UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Starting message receive loop"));


### PR DESCRIPTION
## Summary
- update the sample project's EngineAssociation to Unreal Engine 5.6 so it targets the latest minor release
- harden the TCP receive buffer by naming the constexpr size, allocating an extra byte, and limiting Recv to the usable length as in upstream PR #33

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6a7cf21f0832f88043da6c59f15a4