### PR TITLE
feat(transactions): wrap mutations in Editor transactions; optional Source Control checkout

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Transactions/TransactionManager.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Transactions/TransactionManager.cpp
@@ -1,0 +1,20 @@
+#include "Transactions/TransactionManager.h"
+
+#include "Editor.h"
+
+void FTransactionManager::Begin(const FString& TransactionName)
+{
+        if (GEditor)
+        {
+                const FText TransactionText = FText::FromString(TransactionName);
+                GEditor->BeginTransaction(TransactionText);
+        }
+}
+
+void FTransactionManager::End()
+{
+        if (GEditor)
+        {
+                GEditor->EndTransaction();
+        }
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Permissions/WriteGate.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Permissions/WriteGate.h
@@ -41,6 +41,15 @@ public:
         /** Builds an audit JSON object from a plan. */
         static TSharedPtr<FJsonObject> BuildAuditJson(const FMutationPlan& Plan, bool bExecuted);
 
+        /** Shared transaction label used for MCP-driven mutations. */
+        static const FString& GetTransactionName();
+
+        /** Ensures the target content path is checked out when required by settings. */
+        static bool EnsureCheckoutForContentPath(const FString& ContentPath, TSharedPtr<FJsonObject>& OutError);
+
+        /** Creates a structured error payload for missing source control checkout. */
+        static TSharedPtr<FJsonObject> MakeSourceControlRequiredError(const FString& AssetPath, const FString& FailureMessage = FString());
+
         /** Creates an error payload for write-not-allowed responses. */
         static TSharedPtr<FJsonObject> MakeWriteNotAllowedError(const FString& CommandType);
 

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Transactions/TransactionManager.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Transactions/TransactionManager.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+/** Lightweight helper around editor transactions for MCP-driven mutations. */
+class UNREALMCP_API FTransactionManager
+{
+public:
+        /** Begins a new transaction if the editor is available. */
+        static void Begin(const FString& TransactionName);
+
+        /** Ends the active transaction if the editor is available. */
+        static void End();
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
@@ -46,14 +46,15 @@ public class UnrealMCP : ModuleRules
 				"EditorSubsystem",
 				"Slate",
 				"SlateCore",
-				"UMG",
-				"Kismet",
-				"KismetCompiler",
-				"BlueprintGraph",
-				"Projects",
-				"AssetRegistry"
-			}
-		);
+                                "UMG",
+                                "Kismet",
+                                "KismetCompiler",
+                                "BlueprintGraph",
+                                "Projects",
+                                "AssetRegistry",
+                                "SourceControl"
+                        }
+                );
 		
 		if (Target.bBuildEditor == true)
 		{


### PR DESCRIPTION
## Summary
- add an FTransactionManager helper and wrap mutation commands in an editor transaction
- gate mutations behind optional source control checkout when RequireCheckout is enabled
- enrich audit payloads with transaction metadata and undo availability

## Testing
- not run (Unreal Editor not available in CI)


------
https://chatgpt.com/codex/tasks/task_e_68d6ba6d47c8832fa6194b4928421c49