### PR TITLE
docs: update READMEs (root & Python) for UE5.6 + Protocol v1 + permissions + SCM + assets

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -1,40 +1,67 @@
-# Unreal MCP
+# MCP Python Server
 
-Python bridge for interacting with Unreal Engine 5.5 using the Model Context Protocol (MCP).
+Serveur MCP en Python pour piloter l’Éditeur Unreal via **Protocol v1** (framed JSON).
 
-## Setup
+## Installation
 
-1. Make sure Python 3.10+ is installed
-2. Install `uv` if you haven't already:
-   ```bash
-   curl -LsSf https://astral.sh/uv/install.sh | sh
-   ```
-3. Create and activate a virtual environment:
-   ```bash
-   uv venv
-   source .venv/bin/activate  # On Unix/macOS
-   # or
-   .venv\Scripts\activate     # On Windows
-   ```
-4. Install dependencies:
-   ```bash
-   uv pip install -e .
-   ```
+```bash
+cd Python
+python -m venv .venv
+# Windows: .venv\Scripts\activate
+# macOS/Linux:
+source .venv/bin/activate
 
-At this point, you can configure your MCP Client (Claude Desktop, Cursor, Windsurf) to use the Unreal MCP Server as per the [Configuring your MCP Client](README.md#configuring-your-mcp-client).
+pip install -r requirements.txt  # si présent (sinon, stdlib uniquement)
+```
 
-## Testing Scripts
+> Le serveur n’utilise que la **stdlib** (`socket`, `struct`, `json`, `argparse`, `selectors`, `time`) — aucun package externe requis par défaut.
 
-There are several scripts in the [scripts](./scripts) folder. They are useful for testing the tools and the Unreal Bridge via a direct connection. This means that you do not need to have an MCP Server running.
+## Lancement
 
-You should make sure you have installed dependencies and/or are running in the `uv` virtual environment in order for the scripts to work.
+```bash
+python server.py \
+  --host 127.0.0.1 \
+  --port 12029 \
+  --allow-write 0 \
+  --dry-run 1 \
+  --allowed-path "/Game/Core" \
+  --allowed-path "/Game/Art"
+```
 
+Variables d’environnement supportées :
 
-## Troubleshooting
+* `MCP_ALLOW_WRITE=0|1`
+* `MCP_DRY_RUN=0|1`
+* `MCP_ALLOWED_PATHS=/Game/Core;/Game/Art`
 
-- Make sure Unreal Engine editor is loaded loaded and running before running the server.
-- Check logs in `unreal_mcp.log` for detailed error information
+## Protocol v1 (résumé)
 
-## Development
+* **Framing** : `uint32 length` + payload JSON UTF-8.
+* **Handshake** : client → `{type:"handshake", protocolVersion:1, engineVersion, pluginVersion, sessionId}` ; serveur → `handshake/ack`.
+* **Heartbeats** : `ping` / `pong` (idle 15 s ; timeout 60 s).
+* **Erreurs** : `{ ok:false, error:{ code, message, details } }`.
+* **Compat** : un client legacy reçoit `PROTOCOL_VERSION_MISMATCH` puis fermeture.
 
-To add new tools, modify the `UnrealMCPBridge.py` file to add new command handlers, and update the `unreal_mcp_server.py` file to expose them through the HTTP API. 
+## Sécurité & Enforcement
+
+* Le serveur annonce ses **capabilities/enforcement** (allowWrite/dryRun/allowedPaths).
+* Si une requête indique `meta.mutation=true` et `allowWrite=0` → réponse immédiate `WRITE_NOT_ALLOWED` (le plugin ne tente rien).
+* Un **audit** JSONL est écrit dans `logs/audit.jsonl` (timestamp, tool, mutation, dryRun, digest params, result.ok).
+
+## Outils routés
+
+Le serveur relaie les **tools** vers le plugin UE. Quelques exemples actuels :
+
+* Lecture : `asset.find`, `asset.exists`, `asset.metadata`, `sc.status`
+* Mutations : `sc.checkout`, `sc.add`, `sc.revert`, `sc.submit`
+  *(soumis à allowWrite/dryRun/allowedPaths)*
+
+## Débogage
+
+* Lancer avec `--verbose` (si option dispo) ou consulter les logs côté Éditeur (Saved/Logs).
+* Tester le framing avec un client “echo” local si nécessaire.
+
+## Roadmap (extraits)
+
+* Packs à venir : Actors/Levels, Sequencer avancé, Material Instances set, Niagara spawn & params, BuildCookRun & Gauntlet.
+


### PR DESCRIPTION
## Summary
- refresh the root README to cover UE 5.6 support, Protocol v1, security gates, source control, and asset tools
- update the Python server README with current launch flags, environment variables, protocol details, and audit/security behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7b156cef0832fa07e6fe5c23fb384