### PR TITLE
feat(automation): run_specs (Editor) & gauntlet.run (cooked) with logs/parsing + docs

### DIFF
--- a/Python/automation.py
+++ b/Python/automation.py
@@ -1,0 +1,202 @@
+"""Shared helpers for automation-related MCP tools."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import signal
+import subprocess
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Mapping, MutableMapping, Optional, Sequence
+
+__all__ = [
+    "ToolError",
+    "ProcessResult",
+    "merge_env",
+    "spawn_process",
+    "format_command_for_display",
+    "make_log_path",
+]
+
+
+class ToolError(Exception):
+    """Custom exception used for structured tool errors."""
+
+    def __init__(self, code: str, message: str, details: Optional[Dict[str, object]] = None):
+        super().__init__(message)
+        self.code = code
+        self.details = details or {}
+
+    def to_response(self) -> Dict[str, object]:
+        return {
+            "ok": False,
+            "error": {
+                "code": self.code,
+                "message": str(self),
+                "details": self.details,
+            },
+        }
+
+
+@dataclass
+class ProcessResult:
+    """Represents the outcome of a spawned process."""
+
+    exit_code: Optional[int]
+    duration_seconds: float
+    timed_out: bool
+    log_path: Path
+    last_lines: List[str]
+
+
+def merge_env(custom: Optional[Mapping[str, object]]) -> Dict[str, str]:
+    """Merge a custom environment mapping with the current environment."""
+
+    env: MutableMapping[str, str] = dict(os.environ)
+    if custom:
+        for key, value in custom.items():
+            env[str(key)] = str(value)
+    return dict(env)
+
+
+def _terminate_process(process: subprocess.Popen[str]) -> None:
+    """Attempt to terminate the process tree for the given process."""
+
+    if process.poll() is not None:
+        return
+
+    try:
+        if os.name == "nt":
+            process.send_signal(signal.CTRL_BREAK_EVENT)  # type: ignore[arg-type]
+        else:
+            os.killpg(process.pid, signal.SIGTERM)
+    except Exception:
+        try:
+            process.terminate()
+        except Exception:
+            pass
+
+
+def _kill_process(process: subprocess.Popen[str]) -> None:
+    """Forcefully kill the given process."""
+
+    if process.poll() is not None:
+        return
+    try:
+        if os.name != "nt":
+            os.killpg(process.pid, signal.SIGKILL)
+        process.kill()
+    except Exception:
+        pass
+
+
+def spawn_process(
+    command: Sequence[object],
+    *,
+    log_path: Path,
+    env: Optional[Mapping[str, object]] = None,
+    timeout_seconds: Optional[int] = None,
+) -> ProcessResult:
+    """Spawn an external process, teeing stdout/stderr into a log file."""
+
+    log_path = log_path.expanduser().resolve()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    merged_env = merge_env(env)
+    command_list = [str(part) for part in command]
+
+    creationflags = 0
+    preexec_fn = None
+    if os.name == "nt":
+        creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    else:
+        preexec_fn = os.setsid  # type: ignore[assignment]
+
+    start_time = time.monotonic()
+    process = subprocess.Popen(
+        command_list,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        env=merged_env,
+        creationflags=creationflags,
+        preexec_fn=preexec_fn,
+    )
+
+    last_lines: deque[str] = deque(maxlen=50)
+
+    def _reader() -> None:
+        assert process.stdout is not None
+        with open(log_path, "a", encoding="utf-8", errors="replace") as log_file:
+            for line in iter(process.stdout.readline, ""):
+                log_file.write(line)
+                log_file.flush()
+                last_lines.append(line.rstrip("\n"))
+
+    with open(log_path, "w", encoding="utf-8", errors="replace"):
+        pass
+
+    reader_thread = threading.Thread(target=_reader, daemon=True)
+    reader_thread.start()
+
+    timed_out = False
+    exit_code: Optional[int] = None
+
+    try:
+        exit_code = process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        _terminate_process(process)
+        try:
+            exit_code = process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            _kill_process(process)
+            exit_code = process.wait()
+
+    if process.stdout is not None:
+        try:
+            process.stdout.close()
+        except Exception:
+            pass
+
+    reader_thread.join(timeout=5)
+
+    duration_seconds = time.monotonic() - start_time
+
+    return ProcessResult(
+        exit_code=exit_code,
+        duration_seconds=duration_seconds,
+        timed_out=timed_out,
+        log_path=log_path,
+        last_lines=list(last_lines),
+    )
+
+
+def format_command_for_display(command: Sequence[object]) -> str:
+    """Format a command list into a display-friendly string."""
+
+    command_list = [str(part) for part in command]
+    if os.name == "nt":
+        return subprocess.list2cmdline(command_list)
+    return shlex.join(command_list)
+
+
+def make_log_path(
+    prefix: str,
+    *,
+    root: Path,
+    suffix: str = ".log",
+    timestamp: Optional[str] = None,
+) -> Path:
+    """Return a timestamped log path under the given root."""
+
+    if timestamp is None:
+        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    filename = f"{prefix}_{timestamp}{suffix}"
+    return root.expanduser().resolve() / filename

--- a/Python/automation_specs.py
+++ b/Python/automation_specs.py
@@ -1,0 +1,303 @@
+"""Implementation of the `automation.run_specs` MCP tool."""
+
+from __future__ import annotations
+
+import os
+import platform
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from automation import (
+    ProcessResult,
+    ToolError,
+    format_command_for_display,
+    make_log_path,
+    spawn_process,
+)
+
+LOG_ROOT = Path("logs") / "automation"
+REPORT_ROOT = LOG_ROOT / "reports"
+
+SUMMARY_RE = re.compile(
+    r"LogAutomationController:\s+\w+:\s+Tests? Completed\. \(Pass/Fail/Skipped = (\d+)/(\d+)/(\d+)\)",
+    re.IGNORECASE,
+)
+FAILURE_RE = re.compile(r"LogAutomationController:\s+(Error|Warning):\s+(.*)")
+
+
+@dataclass
+class AutomationSpecsConfig:
+    """Parsed configuration for Automation RunTests invocations."""
+
+    engine_root: Path
+    uproject: Path
+    tests: List[str]
+    map_name: Optional[str]
+    timeout_seconds: Optional[int]
+    headless: bool
+    extra_args: List[str]
+    env: Dict[str, str]
+
+    @property
+    def editor_cmd(self) -> Path:
+        binaries_dir = self.engine_root / "Engine" / "Binaries"
+        system_name = platform.system().lower()
+        if system_name.startswith("windows"):
+            return binaries_dir / "Win64" / "UnrealEditor-Cmd.exe"
+        if system_name.startswith("darwin") or "mac" in system_name:
+            return binaries_dir / "Mac" / "UnrealEditor-Cmd"
+        return binaries_dir / "Linux" / "UnrealEditor-Cmd"
+
+
+def _parse_timeout(payload: Dict[str, Any]) -> Optional[int]:
+    timeout_minutes = payload.get("timeoutMinutes")
+    if timeout_minutes is None:
+        return None
+    try:
+        timeout_value = float(timeout_minutes)
+    except (TypeError, ValueError):
+        raise ToolError("INVALID_TIMEOUT", "timeoutMinutes must be numeric.")
+    if timeout_value <= 0:
+        return None
+    return int(timeout_value * 60)
+
+
+def _normalize_string_sequence(value: Any, *, default: Optional[Sequence[str]] = None) -> List[str]:
+    if value is None:
+        return list(default or [])
+    if isinstance(value, (list, tuple, set)):
+        return [str(item) for item in value]
+    return [str(value)]
+
+
+def _ensure_path(path_str: Any, *, code: str, what: str) -> Path:
+    if not path_str:
+        raise ToolError(code, f"{what} is required.")
+    candidate = Path(str(path_str)).expanduser().resolve()
+    if not candidate.exists():
+        raise ToolError(code, f"{what} does not exist.", {what: str(candidate)})
+    return candidate
+
+
+def _build_exec_cmds(tests: Sequence[str]) -> str:
+    commands = [f"Automation RunTests {test}" for test in tests if test]
+    commands.append("Quit")
+    return "; ".join(commands)
+
+
+def _pick_report_xml(report_dir: Path) -> Optional[Path]:
+    if not report_dir.exists():
+        return None
+    xml_files = sorted(report_dir.glob("*.xml"))
+    if xml_files:
+        return xml_files[0]
+    return None
+
+
+def _parse_failures(log_path: Path) -> List[Dict[str, str]]:
+    failures: List[Dict[str, str]] = []
+    with open(log_path, "r", encoding="utf-8", errors="replace") as log_file:
+        for line in log_file:
+            match = FAILURE_RE.search(line)
+            if not match:
+                continue
+            remainder = match.group(2).strip()
+            test_name = ""
+            message = remainder
+            if ":" in remainder:
+                potential_test, potential_message = remainder.split(":", 1)
+                if potential_test.strip():
+                    test_name = potential_test.strip()
+                    message = potential_message.strip()
+            elif " - " in remainder:
+                potential_test, potential_message = remainder.split(" - ", 1)
+                test_name = potential_test.strip()
+                message = potential_message.strip()
+            failures.append({"test": test_name, "message": message})
+    return failures
+
+
+def _parse_summary(log_path: Path) -> Optional[Dict[str, int]]:
+    with open(log_path, "r", encoding="utf-8", errors="replace") as log_file:
+        for line in log_file:
+            match = SUMMARY_RE.search(line)
+            if match:
+                passed = int(match.group(1))
+                failed = int(match.group(2))
+                skipped = int(match.group(3))
+                total = passed + failed + skipped
+                return {
+                    "total": total,
+                    "passed": passed,
+                    "failed": failed,
+                    "skipped": skipped,
+                }
+    return None
+
+
+def _parse_results(log_path: Path) -> Tuple[Dict[str, Any], bool]:
+    summary = _parse_summary(log_path)
+    failures = _parse_failures(log_path)
+    parse_error = summary is None
+    if summary is None:
+        summary = {"total": 0, "passed": 0, "failed": 0, "skipped": 0}
+    summary["failures"] = failures
+    return summary, parse_error
+
+
+def _build_command(config: AutomationSpecsConfig, report_dir: Path) -> List[str]:
+    command: List[str] = [str(config.editor_cmd), str(config.uproject)]
+    command.append("-RunAutomationTests")
+    command.append(f"-Project={config.uproject}")
+    command.append(f'-ExecCmds="{_build_exec_cmds(config.tests)}"')
+    command.extend(["-log", "-unattended", "-NoSplash"])
+    if config.headless:
+        command.append("-NullRHI")
+    if config.map_name:
+        command.append(f"-Map={config.map_name}")
+    command.append(f"-ReportExportPath={report_dir}")
+    command.extend(config.extra_args)
+    return command
+
+
+def _parse_payload(payload: Optional[Dict[str, Any]]) -> AutomationSpecsConfig:
+    payload = payload or {}
+    if not isinstance(payload, dict):
+        raise ToolError("INVALID_PARAMS", "Expected params to be an object.")
+
+    engine_root = _ensure_path(
+        payload.get("engineRoot") or os.getenv("UE_ENGINE_ROOT"),
+        code="ENGINE_NOT_FOUND",
+        what="engineRoot",
+    )
+    editor_binary = engine_root / "Engine"
+    if not editor_binary.exists():
+        raise ToolError("ENGINE_NOT_FOUND", "engineRoot does not appear to be a valid Unreal Engine installation.")
+
+    uproject = _ensure_path(payload.get("uproject"), code="UPROJECT_NOT_FOUND", what="uproject")
+
+    tests = _normalize_string_sequence(payload.get("tests"), default=["All"])
+    if not tests:
+        tests = ["All"]
+
+    timeout_seconds = _parse_timeout(payload)
+    headless = bool(payload.get("headless", False))
+    extra_args = _normalize_string_sequence(payload.get("extraArgs"), default=[])
+    env_raw = payload.get("env") or {}
+    if not isinstance(env_raw, dict):
+        raise ToolError("INVALID_ENV", "env must be an object of key/value pairs.")
+    env = {str(key): str(value) for key, value in env_raw.items()}
+
+    map_name = payload.get("map")
+    if map_name is not None:
+        map_name = str(map_name)
+
+    config = AutomationSpecsConfig(
+        engine_root=engine_root,
+        uproject=uproject,
+        tests=tests,
+        map_name=map_name,
+        timeout_seconds=timeout_seconds,
+        headless=headless,
+        extra_args=extra_args,
+        env=env,
+    )
+
+    editor_cmd = config.editor_cmd
+    if not editor_cmd.exists():
+        raise ToolError(
+            "ENGINE_NOT_FOUND",
+            "UnrealEditor-Cmd executable not found under engineRoot.",
+            {"expected": str(editor_cmd)},
+        )
+
+    return config
+
+
+def run_specs(payload: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Execute Unreal Automation Tests via UnrealEditor-Cmd."""
+
+    try:
+        config = _parse_payload(payload)
+    except ToolError as exc:
+        return exc.to_response()
+
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    log_path = make_log_path("automation", root=LOG_ROOT, timestamp=timestamp)
+    report_dir = (REPORT_ROOT / f"report_{timestamp}").expanduser().resolve()
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    command = _build_command(config, report_dir)
+
+    result: ProcessResult = spawn_process(
+        command,
+        log_path=log_path,
+        env=config.env,
+        timeout_seconds=config.timeout_seconds,
+    )
+
+    if result.timed_out:
+        return ToolError(
+            "TIMEOUT",
+            "UnrealEditor-Cmd timed out while running automation tests.",
+            {"timeoutSeconds": config.timeout_seconds, "log": str(result.log_path)},
+        ).to_response()
+
+    if result.exit_code is None:
+        return ToolError(
+            "PROCESS_FAILED",
+            "UnrealEditor-Cmd did not provide an exit code.",
+            {"log": str(result.log_path)},
+        ).to_response()
+
+    summary, parse_error = _parse_results(result.log_path)
+    report_xml = _pick_report_xml(report_dir)
+
+    response: Dict[str, Any] = {
+        "ok": result.exit_code == 0,
+        "exitCode": result.exit_code,
+        "durationSec": int(result.duration_seconds),
+        "editorCmd": format_command_for_display(command),
+        "results": summary,
+        "logs": {"editorLog": str(result.log_path)},
+    }
+
+    if report_xml is not None:
+        response["logs"]["reportXML"] = str(report_xml)
+
+    if parse_error:
+        response.setdefault("error", {
+            "code": "REPORT_PARSE_FAILED",
+            "message": "Unable to parse automation test summary from log.",
+            "details": {"log": str(result.log_path)},
+        })
+    elif summary.get("failed"):
+        failures = summary.get("failures", [])
+        if failures:
+            response.setdefault("error", {
+                "code": "TESTS_FAILED",
+                "message": "One or more automation tests failed.",
+                "details": {"failures": failures[:10]},
+            })
+
+    if result.exit_code != 0:
+        response.setdefault(
+            "error",
+            {
+                "code": "PROCESS_FAILED",
+                "message": "UnrealEditor-Cmd exited with a non-zero status.",
+                "details": {
+                    "exitCode": result.exit_code,
+                    "log": str(result.log_path),
+                    "tail": result.last_lines,
+                },
+            },
+        )
+
+    return response
+
+
+__all__ = ["run_specs"]

--- a/Python/gauntlet.py
+++ b/Python/gauntlet.py
@@ -1,0 +1,279 @@
+"""Implementation of the `gauntlet.run` MCP tool."""
+
+from __future__ import annotations
+
+import os
+import platform
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from automation import (
+    ProcessResult,
+    ToolError,
+    format_command_for_display,
+    make_log_path,
+    spawn_process,
+)
+
+LOG_ROOT = Path("logs") / "gauntlet"
+
+RESULT_RE = re.compile(r"Results?\s*-\s*Total:\s*(\d+),\s*Passed:\s*(\d+),\s*Failed:\s*(\d+)", re.IGNORECASE)
+GAUNTLET_LOG_PATTERNS = [
+    re.compile(r"Gauntlet\s*(?:Log|log file)[:=]\s*(.+)", re.IGNORECASE),
+    re.compile(r"Log file:\s*(.+Gauntlet.+\.log)", re.IGNORECASE),
+]
+ARTIFACT_PATTERNS = [
+    re.compile(r"Artifacts?\s*(?:Dir|Directory|stored at|saved to)[:=]\s*(.+)", re.IGNORECASE),
+]
+
+
+@dataclass
+class GauntletConfig:
+    """Configuration for a Gauntlet run."""
+
+    engine_root: Path
+    runuat_path: Path
+    uproject: Path
+    test_name: str
+    platform_name: str
+    client_config: str
+    build_path: Path
+    timeout_seconds: Optional[int]
+    extra_args: List[str]
+    env: Dict[str, str]
+
+
+def _parse_timeout(payload: Dict[str, Any]) -> Optional[int]:
+    timeout_minutes = payload.get("timeoutMinutes")
+    if timeout_minutes is None:
+        return None
+    try:
+        timeout_value = float(timeout_minutes)
+    except (TypeError, ValueError):
+        raise ToolError("INVALID_TIMEOUT", "timeoutMinutes must be numeric.")
+    if timeout_value <= 0:
+        return None
+    return int(timeout_value * 60)
+
+
+def _normalize_string_sequence(value: Any, *, default: Optional[Sequence[str]] = None) -> List[str]:
+    if value is None:
+        return list(default or [])
+    if isinstance(value, (list, tuple, set)):
+        return [str(item) for item in value]
+    return [str(value)]
+
+
+def _ensure_path(path_str: Any, *, code: str, what: str) -> Path:
+    if not path_str:
+        raise ToolError(code, f"{what} is required.")
+    candidate = Path(str(path_str)).expanduser().resolve()
+    if not candidate.exists():
+        raise ToolError(code, f"{what} does not exist.", {what: str(candidate)})
+    return candidate
+
+
+def _locate_runuat(engine_root: Path) -> Path:
+    binaries_dir = engine_root / "Engine" / "Build" / "BatchFiles"
+    system_name = platform.system().lower()
+    if system_name.startswith("windows"):
+        candidate = binaries_dir / "RunUAT.bat"
+    else:
+        candidate = binaries_dir / "RunUAT.sh"
+    if not candidate.exists():
+        raise ToolError(
+            "ENGINE_NOT_FOUND",
+            "RunUAT script not found under engineRoot.",
+            {"expected": str(candidate)},
+        )
+    return candidate
+
+
+def _clean_path(value: str) -> str:
+    cleaned = value.strip().strip('"').strip("'")
+    return cleaned
+
+
+def _parse_gauntlet_log(log_path: Path) -> Tuple[Dict[str, Any], bool, Optional[str]]:
+    total: Optional[int] = None
+    passed: Optional[int] = None
+    failed: Optional[int] = None
+    artifacts_dir: Optional[str] = None
+    gauntlet_log: Optional[str] = None
+
+    with open(log_path, "r", encoding="utf-8", errors="replace") as log_file:
+        for line in log_file:
+            if total is None or passed is None or failed is None:
+                match = RESULT_RE.search(line)
+                if match:
+                    total = int(match.group(1))
+                    passed = int(match.group(2))
+                    failed = int(match.group(3))
+            if artifacts_dir is None:
+                for pattern in ARTIFACT_PATTERNS:
+                    match = pattern.search(line)
+                    if match:
+                        artifacts_dir = _clean_path(match.group(1))
+                        break
+            if gauntlet_log is None:
+                for pattern in GAUNTLET_LOG_PATTERNS:
+                    match = pattern.search(line)
+                    if match:
+                        gauntlet_log = _clean_path(match.group(1))
+                        break
+
+    parse_error = total is None or passed is None or failed is None
+    results: Dict[str, Any] = {
+        "total": total or 0,
+        "passed": passed or 0,
+        "failed": failed or 0,
+    }
+    if artifacts_dir:
+        results["artifactsDir"] = artifacts_dir
+
+    return results, parse_error, gauntlet_log
+
+
+def _parse_payload(payload: Optional[Dict[str, Any]]) -> GauntletConfig:
+    payload = payload or {}
+    if not isinstance(payload, dict):
+        raise ToolError("INVALID_PARAMS", "Expected params to be an object.")
+
+    engine_root = _ensure_path(payload.get("engineRoot") or os.getenv("UE_ENGINE_ROOT"), code="ENGINE_NOT_FOUND", what="engineRoot")
+    runuat_path = _locate_runuat(engine_root)
+
+    uproject = _ensure_path(payload.get("uproject"), code="UPROJECT_NOT_FOUND", what="uproject")
+
+    test_name = payload.get("test")
+    if not test_name:
+        raise ToolError("INVALID_PARAMS", "test is required (Gauntlet suite name).")
+    test_name = str(test_name)
+
+    platform_name = payload.get("platform")
+    if not platform_name:
+        raise ToolError("PLATFORM_UNSUPPORTED", "platform is required.")
+    platform_name = str(platform_name)
+
+    client_config = str(payload.get("config") or "Development")
+
+    build_payload = payload.get("build") or {}
+    if not isinstance(build_payload, dict):
+        raise ToolError("BUILD_PATH_NOT_FOUND", "build must be an object containing 'path'.")
+    build_path = _ensure_path(build_payload.get("path"), code="BUILD_PATH_NOT_FOUND", what="buildPath")
+
+    timeout_seconds = _parse_timeout(payload)
+
+    extra_args = _normalize_string_sequence(payload.get("extraArgs"), default=[])
+    env_raw = payload.get("env") or {}
+    if not isinstance(env_raw, dict):
+        raise ToolError("INVALID_ENV", "env must be an object of key/value pairs.")
+    env = {str(key): str(value) for key, value in env_raw.items()}
+
+    return GauntletConfig(
+        engine_root=engine_root,
+        runuat_path=runuat_path,
+        uproject=uproject,
+        test_name=test_name,
+        platform_name=str(platform_name),
+        client_config=client_config,
+        build_path=build_path,
+        timeout_seconds=timeout_seconds,
+        extra_args=extra_args,
+        env=env,
+    )
+
+
+def _build_command(config: GauntletConfig) -> List[str]:
+    command: List[str] = [
+        str(config.runuat_path),
+        "Gauntlet",
+        f'-project="{config.uproject}"',
+        f"-test={config.test_name}",
+        f"-platform={config.platform_name}",
+        f"-clientconfig={config.client_config}",
+        f'-builds="{config.build_path}"',
+        "-log",
+        "-unattended",
+    ]
+    command.extend(config.extra_args)
+    return command
+
+
+def run_gauntlet(payload: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Execute a Gauntlet test run via RunUAT."""
+
+    try:
+        config = _parse_payload(payload)
+    except ToolError as exc:
+        return exc.to_response()
+
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    log_path = make_log_path("gauntlet_uat", root=LOG_ROOT, timestamp=timestamp)
+
+    command = _build_command(config)
+    result: ProcessResult = spawn_process(
+        command,
+        log_path=log_path,
+        env=config.env,
+        timeout_seconds=config.timeout_seconds,
+    )
+
+    if result.timed_out:
+        return ToolError(
+            "TIMEOUT",
+            "RunUAT Gauntlet timed out.",
+            {"timeoutSeconds": config.timeout_seconds, "log": str(result.log_path)},
+        ).to_response()
+
+    if result.exit_code is None:
+        return ToolError(
+            "PROCESS_FAILED",
+            "RunUAT did not provide an exit code.",
+            {"log": str(result.log_path)},
+        ).to_response()
+
+    results, parse_error, gauntlet_log = _parse_gauntlet_log(result.log_path)
+
+    response: Dict[str, Any] = {
+        "ok": result.exit_code == 0,
+        "exitCode": result.exit_code,
+        "durationSec": int(result.duration_seconds),
+        "uatCmd": format_command_for_display(command),
+        "results": results,
+        "logs": {"uatLog": str(result.log_path)},
+    }
+
+    if gauntlet_log:
+        response["logs"]["gauntletLog"] = gauntlet_log
+
+    if parse_error:
+        response.setdefault(
+            "error",
+            {
+                "code": "REPORT_PARSE_FAILED",
+                "message": "Unable to parse Gauntlet summary from RunUAT log.",
+                "details": {"log": str(result.log_path)},
+            },
+        )
+
+    if result.exit_code != 0:
+        response.setdefault(
+            "error",
+            {
+                "code": "PROCESS_FAILED",
+                "message": "RunUAT exited with a non-zero status.",
+                "details": {
+                    "exitCode": result.exit_code,
+                    "log": str(result.log_path),
+                    "tail": result.last_lines,
+                },
+            },
+        )
+
+    return response
+
+
+__all__ = ["run_gauntlet"]

--- a/Python/server.py
+++ b/Python/server.py
@@ -6,6 +6,8 @@ from typing import Any, Dict
 
 from mcp.server.fastmcp import Context, FastMCP
 
+from automation_specs import run_specs
+from gauntlet import run_gauntlet
 from uat import run_buildcookrun
 
 
@@ -32,6 +34,45 @@ def register_server_tools(mcp: FastMCP) -> None:
 
         return run_buildcookrun(payload)
 
+    @mcp.tool(name="automation.run_specs")
+    def _automation_run_specs(ctx: Context, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Run Unreal Automation Tests via UnrealEditor-Cmd."""
+
+        if params is None:
+            payload = {}
+        elif isinstance(params, dict):
+            payload = params
+        else:
+            return {
+                "ok": False,
+                "error": {
+                    "code": "INVALID_PARAMS",
+                    "message": "Expected params to be an object for automation.run_specs.",
+                    "details": {"receivedType": type(params).__name__},
+                },
+            }
+
+        return run_specs(payload)
+
+    @mcp.tool(name="gauntlet.run")
+    def _gauntlet_run(ctx: Context, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Run a Gauntlet suite via RunUAT."""
+
+        if params is None:
+            payload = {}
+        elif isinstance(params, dict):
+            payload = params
+        else:
+            return {
+                "ok": False,
+                "error": {
+                    "code": "INVALID_PARAMS",
+                    "message": "Expected params to be an object for gauntlet.run.",
+                    "details": {"receivedType": type(params).__name__},
+                },
+            }
+
+        return run_gauntlet(payload)
 
 __all__ = ["register_server_tools"]
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **Niagara v1 (Editor)** : `niagara.spawn_component / niagara.set_user_params / niagara.activate / niagara.deactivate`.
 - **Actors v1 (Editor)** : `actor.spawn / actor.destroy / actor.attach / actor.transform / actor.tag` (transactions, sélection, audit).
 - **Camera helpers (Editor)** : `level.select / viewport.focus / camera.bookmark` (navigation + bookmarks, session & persistance).
-- **Build & Test v1** : wrapper RunUAT `BuildCookRun` côté serveur Python (logs persistants, artefacts, dry-run).
+- **Build & Test v2** : wrappers RunUAT `BuildCookRun`, `automation.run_specs` (Editor-Cmd) et `gauntlet.run` (cooked) avec logs persistants & parsing basique.
 - **Settings Plugin** : Project Settings → **Plugins → Unreal MCP** (Network, Security, SCM, Logging, Diagnostics).
 
 ## 🔧 Installation rapide
@@ -283,6 +283,8 @@
 | Tool               | Type     | Description                                     | Notes                                |
 | ------------------ | -------- | ----------------------------------------------- | ------------------------------------ |
 | `uat.buildcookrun` | external | Lance RunUAT BuildCookRun (cook/stage/package…) | Logs persistants, artefacts, dry-run |
+| `automation.run_specs` | external | Lance Automation Tests via UnrealEditor-Cmd | Export log/XML, parsing basique |
+| `gauntlet.run` | external | Lance Gauntlet sur build packagé | Logs UAT + Gauntlet, artifacts |
 
 ```json
 {
@@ -297,6 +299,14 @@
     "archive": true
   }
 }
+```
+
+```json
+{"tool":"automation.run_specs","params":{"engineRoot":"D:/UE_5.6","uproject":"D:/Proj/MyGame/MyGame.uproject","tests":["Project.Functional"],"timeoutMinutes":30}}
+```
+
+```json
+{"tool":"gauntlet.run","params":{"engineRoot":"D:/UE_5.6","uproject":"D:/Proj/MyGame/MyGame.uproject","test":"MyGauntletSuite","platform":"Win64","build":{"path":"D:/Builds/MyGame/WindowsNoEditor"}}}
 ```
 
   > **Transactions & Undo** : chaque mutation est faite dans une transaction éditeur (Ctrl+Z possible).


### PR DESCRIPTION
## Summary
- add shared automation helpers for spawning subprocesses with logging, timeouts, and command formatting
- expose new automation.run_specs and gauntlet.run tools on the MCP server, including log parsing and structured responses
- document the new automation tooling in both the root README and Python server guide

## Testing
- python -m compileall Python/automation_specs.py Python/gauntlet.py

------
https://chatgpt.com/codex/tasks/task_e_68da8a55a67c832facbb68e3474461b5