### PR TITLE
feat(cli): local mcp CLI (run, recipes, dry-run, retry, parallel) + docs

### DIFF
--- a/Python/cli/README.md
+++ b/Python/cli/README.md
@@ -1,0 +1,63 @@
+# MCP CLI
+
+CLI Typer permettant de piloter le serveur Unreal MCP depuis la ligne de commande.
+
+## Installation
+
+```bash
+cd Python/cli
+pip install -e .
+```
+
+La commande `mcp` est alors disponible (`mcp --help`). Le serveur cible peut être indiqué via `--server` ou la variable d’environnement `MCP_SERVER` (`127.0.0.1:8765` par défaut).
+
+## Commandes principales
+
+| Commande              | Description                                                 |
+|-----------------------|-------------------------------------------------------------|
+| `mcp run`             | Exécute un tool MCP unique avec paramètres JSON/YAML        |
+| `mcp recipe run`      | Exécute une recette YAML (steps, dépendances, parallelisme) |
+| `mcp recipe test`     | Valide la recette, affiche le plan, dry-run optionnel       |
+
+Options transverses : `--dry-run`, `--retry`, `--parallel`, `--timeout`, `--vars`/`--vars-file`, `--select` (JMESPath), `--output json|yaml`, `--log-level`, `--env KEY=VALUE`.
+
+## Exemples rapides
+
+```bash
+# Tool simple
+mcp run level.save_open --params-json '{"modifiedOnly":true}'
+
+# Pipeline YAML avec variables
+mcp recipe run ./pipelines/content_cleanup.yaml --vars GAME_ROOT=/Game/Core
+
+# Test d'une recette (plan + audits dry-run)
+mcp recipe test ./pipelines/content_cleanup.yaml --dry-run --output yaml
+```
+
+## Format de recette
+
+```yaml
+version: 1
+vars:
+  GAME_ROOT: "/Game/Core"
+steps:
+  - name: import-assets
+    tool: asset.batch_import
+    params:
+      destPath: "${GAME_ROOT}/Props"
+      files:
+        - "D:/Imports/Chair.fbx"
+      preset: "fbx_static"
+    retry:
+      max_attempts: 3
+      backoff_sec: 2
+  - name: export-seq
+    tool: sequence.export
+    needs: [import-assets]
+    params:
+      sequencePath: "${{ steps.import-assets.result.sequencePath }}"
+      format: json
+    save_as: out/seq.json
+```
+
+Les variables `${VAR}` proviennent du fichier, de `--vars-file`, de `--vars` et de l’environnement. Les expressions `${{ steps.* }}` accèdent aux sorties des steps précédents. Les audits (`actions`/`diffs`) sont fusionnés dans le récapitulatif final.

--- a/Python/cli/__main__.py
+++ b/Python/cli/__main__.py
@@ -1,0 +1,14 @@
+"""Entry point for the ``mcp`` command line interface."""
+
+from __future__ import annotations
+
+from mcp_cli.cli import app
+
+
+def main() -> None:
+    """Execute the Typer application."""
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/Python/cli/mcp_cli/__init__.py
+++ b/Python/cli/mcp_cli/__init__.py
@@ -1,0 +1,7 @@
+"""Local CLI for interacting with the Unreal MCP server."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/Python/cli/mcp_cli/cli.py
+++ b/Python/cli/mcp_cli/cli.py
@@ -1,0 +1,290 @@
+"""Command line interface implementation for the MCP client."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import jmespath
+import typer
+import yaml
+
+from .logs import configure_logging, get_logger
+from .mcp_client import MCPClient, ProtocolError
+from .recipes import (
+    LoadedRecipe,
+    RecipeExecutor,
+    load_recipe_file,
+    merge_variables,
+    render_value,
+)
+from .schema import SchemaError
+
+app = typer.Typer(help="Interact with the Unreal MCP server from the command line.")
+recipe_app = typer.Typer(help="Work with pipeline recipes defined in YAML files.")
+app.add_typer(recipe_app, name="recipe")
+
+
+def _parse_key_values(pairs: List[str], *, option: str) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    for item in pairs:
+        if "=" not in item:
+            raise typer.BadParameter(f"Expected KEY=VALUE format for {option}")
+        key, value = item.split("=", 1)
+        if not key:
+            raise typer.BadParameter(f"Invalid key for {option}")
+        values[key] = value
+    return values
+
+
+def _load_vars_file(path: Optional[Path]) -> Dict[str, Any]:
+    if not path:
+        return {}
+    resolved = path.expanduser().resolve()
+    if not resolved.exists():
+        raise typer.BadParameter(f"Vars file not found: {resolved}")
+    with resolved.open("r", encoding="utf-8") as handle:
+        text = handle.read()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise typer.BadParameter("Vars file must contain a mapping")
+    return data
+
+
+def _load_params_source(params_json: Optional[str], params_file: Optional[Path]) -> Any:
+    payload: Any = None
+    if params_file:
+        resolved = params_file.expanduser().resolve()
+        if not resolved.exists():
+            raise typer.BadParameter(f"Params file not found: {resolved}")
+        with resolved.open("r", encoding="utf-8") as handle:
+            text = handle.read()
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            payload = yaml.safe_load(text)
+    elif params_json:
+        try:
+            payload = json.loads(params_json)
+        except json.JSONDecodeError as exc:
+            raise typer.BadParameter(f"Invalid JSON for --params-json: {exc}") from exc
+    if payload is None:
+        payload = {}
+    return payload
+
+
+def _apply_env_overrides(overrides: Dict[str, str]) -> None:
+    for key, value in overrides.items():
+        os.environ[key] = value
+
+
+def _format_output(data: Any, *, output: str) -> str:
+    fmt = output.lower()
+    if fmt not in {"json", "yaml"}:
+        raise typer.BadParameter("--output must be either 'json' or 'yaml'")
+    if fmt == "yaml":
+        return yaml.safe_dump(data, sort_keys=False)
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def _apply_select(data: Any, select: Optional[str]) -> Any:
+    if not select:
+        return data
+    return jmespath.search(select, data)
+
+
+def _configure_and_get_logger(level: str, name: str):
+    configure_logging(level)
+    return get_logger(name)
+
+
+def _parse_recipe_reference(reference: str) -> Tuple[Path, Optional[str]]:
+    if "#" in reference:
+        path_part, recipe_name = reference.split("#", 1)
+        return Path(path_part), recipe_name or None
+    return Path(reference), None
+
+
+def _build_recipe(
+    recipe_path: Path,
+    recipe_name: Optional[str],
+) -> LoadedRecipe:
+    try:
+        return load_recipe_file(recipe_path, recipe_name)
+    except (SchemaError, FileNotFoundError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+
+@app.command("run")
+def run_tool(
+    tool: str = typer.Argument(..., help="Name of the MCP tool to execute."),
+    params_json: Optional[str] = typer.Option(None, "--params-json", help="Inline JSON parameters."),
+    params_file: Optional[Path] = typer.Option(None, "--params-file", help="Path to a JSON/YAML file with parameters."),
+    server: str = typer.Option("127.0.0.1:8765", "--server", envvar="MCP_SERVER", help="Address of the MCP server."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Mark the invocation as a dry-run."),
+    retry: int = typer.Option(1, "--retry", min=1, help="Number of retry attempts on transport errors."),
+    timeout: Optional[float] = typer.Option(None, "--timeout", help="Seconds to wait for tool response."),
+    vars_inline: List[str] = typer.Option([], "--vars", help="Variables to substitute (KEY=VALUE)."),
+    vars_file: Optional[Path] = typer.Option(None, "--vars-file", help="YAML/JSON file containing variables."),
+    env_overrides: List[str] = typer.Option([], "--env", help="Environment overrides (KEY=VALUE)."),
+    select: Optional[str] = typer.Option(None, "--select", help="JMESPath expression to filter the result."),
+    output: str = typer.Option("json", "--output", case_sensitive=False, help="Output format: json or yaml."),
+    log_level: str = typer.Option("info", "--log-level", help="Logging level."),
+) -> None:
+    logger = _configure_and_get_logger(log_level, "command.run")
+    env_vars = _parse_key_values(env_overrides, option="--env")
+    _apply_env_overrides(env_vars)
+
+    cli_vars = _parse_key_values(vars_inline, option="--vars")
+    file_vars = _load_vars_file(vars_file)
+    variables = merge_variables({}, cli_vars, file_vars)
+    context = {"vars": variables, "steps": {}}
+
+    params = _load_params_source(params_json, params_file)
+    params = render_value(params, variables, context) if params is not None else {}
+    if dry_run and isinstance(params, dict) and "DryRun" not in params:
+        params = dict(params)
+        params.setdefault("DryRun", True)
+
+    meta = {"dryRun": dry_run, "vars": variables}
+    report: Dict[str, Any]
+    client = MCPClient(server)
+    try:
+        response = client.call_with_retry(
+            tool,
+            params,
+            meta=meta,
+            attempts=retry,
+            timeout=timeout,
+        )
+    except ProtocolError as exc:
+        logger.error("Transport error: %s", exc)
+        raise typer.Exit(1) from exc
+    except OSError as exc:
+        logger.error("Socket error: %s", exc)
+        raise typer.Exit(1) from exc
+    finally:
+        client.close()
+
+    selected = _apply_select(response, select)
+    print(_format_output(selected, output=output.lower()))
+
+    ok = bool(response.get("ok", False)) if isinstance(response, dict) else False
+    raise typer.Exit(0 if ok else 1)
+
+
+@recipe_app.command("run")
+def run_recipe(
+    recipe: str = typer.Argument(..., help="Path to the recipe YAML file (optionally with #recipe)."),
+    server: str = typer.Option("127.0.0.1:8765", "--server", envvar="MCP_SERVER", help="Address of the MCP server."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Invoke each step with DryRun=true when possible."),
+    retry: int = typer.Option(1, "--retry", min=1, help="Default retry attempts per step."),
+    parallel: int = typer.Option(1, "--parallel", min=1, help="Maximum parallel steps to execute."),
+    continue_on_error: bool = typer.Option(False, "--continue-on-error", help="Continue executing steps after failures."),
+    timeout: Optional[float] = typer.Option(None, "--timeout", help="Default timeout (seconds) for each step."),
+    vars_inline: List[str] = typer.Option([], "--vars", help="Variables to inject (KEY=VALUE)."),
+    vars_file: Optional[Path] = typer.Option(None, "--vars-file", help="YAML/JSON file containing variables."),
+    env_overrides: List[str] = typer.Option([], "--env", help="Environment overrides (KEY=VALUE)."),
+    select: Optional[str] = typer.Option(None, "--select", help="JMESPath expression to filter the summary."),
+    output: str = typer.Option("json", "--output", case_sensitive=False, help="Output format: json or yaml."),
+    log_level: str = typer.Option("info", "--log-level", help="Logging level."),
+) -> None:
+    logger = _configure_and_get_logger(log_level, "command.recipe.run")
+    env_vars = _parse_key_values(env_overrides, option="--env")
+    _apply_env_overrides(env_vars)
+
+    recipe_path, recipe_name = _parse_recipe_reference(recipe)
+    loaded = _build_recipe(recipe_path, recipe_name)
+
+    cli_vars = _parse_key_values(vars_inline, option="--vars")
+    file_vars = _load_vars_file(vars_file)
+    variables = merge_variables(loaded.recipe.vars, cli_vars, file_vars)
+
+    client = MCPClient(server)
+    executor = RecipeExecutor(client, loaded, variables=variables)
+    plan = executor.plan()
+    logger.info("Plan: %s", " -> ".join(plan))
+
+    try:
+        summary = executor.execute(
+            dry_run=dry_run,
+            default_retry=retry,
+            parallelism=parallel,
+            continue_on_error=continue_on_error,
+            default_timeout=timeout,
+            allow_save=True,
+        )
+    finally:
+        client.close()
+
+    selected = _apply_select(summary, select)
+    print(_format_output(selected, output=output.lower()))
+
+    raise typer.Exit(0 if summary.get("ok") else 1)
+
+
+@recipe_app.command("test")
+def test_recipe(
+    recipe: str = typer.Argument(..., help="Path to the recipe YAML file (optionally with #recipe)."),
+    server: str = typer.Option("127.0.0.1:8765", "--server", envvar="MCP_SERVER", help="Address of the MCP server."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Execute steps in dry-run mode to collect audits."),
+    retry: int = typer.Option(1, "--retry", min=1, help="Default retry attempts per step."),
+    parallel: int = typer.Option(1, "--parallel", min=1, help="Maximum parallel steps to execute."),
+    timeout: Optional[float] = typer.Option(None, "--timeout", help="Default timeout (seconds) for each step."),
+    vars_inline: List[str] = typer.Option([], "--vars", help="Variables to inject (KEY=VALUE)."),
+    vars_file: Optional[Path] = typer.Option(None, "--vars-file", help="YAML/JSON file containing variables."),
+    env_overrides: List[str] = typer.Option([], "--env", help="Environment overrides (KEY=VALUE)."),
+    select: Optional[str] = typer.Option(None, "--select", help="JMESPath expression to filter the test report."),
+    output: str = typer.Option("json", "--output", case_sensitive=False, help="Output format: json or yaml."),
+    log_level: str = typer.Option("info", "--log-level", help="Logging level."),
+) -> None:
+    _ = server  # server kept for parity; only used when dry-run executes steps.
+    logger = _configure_and_get_logger(log_level, "command.recipe.test")
+    env_vars = _parse_key_values(env_overrides, option="--env")
+    _apply_env_overrides(env_vars)
+
+    recipe_path, recipe_name = _parse_recipe_reference(recipe)
+    loaded = _build_recipe(recipe_path, recipe_name)
+
+    cli_vars = _parse_key_values(vars_inline, option="--vars")
+    file_vars = _load_vars_file(vars_file)
+    variables = merge_variables(loaded.recipe.vars, cli_vars, file_vars)
+
+    client = MCPClient(server)
+    try:
+        plan_executor = RecipeExecutor(client, loaded, variables=variables)
+        plan = plan_executor.plan()
+
+        report: Dict[str, Any] = {
+            "recipe": loaded.recipe.name,
+            "plan": plan,
+            "vars": variables,
+        }
+
+        if dry_run:
+            executor = RecipeExecutor(client, loaded, variables=variables)
+            logger.info("Executing dry-run against MCP server %s", server)
+            summary = executor.execute(
+                dry_run=True,
+                default_retry=retry,
+                parallelism=parallel,
+                continue_on_error=True,
+                default_timeout=timeout,
+                allow_save=False,
+            )
+            report["dryRun"] = summary
+            report["ok"] = summary.get("ok", False)
+        else:
+            report["ok"] = True
+    finally:
+        client.close()
+
+    selected = _apply_select(report, select)
+    print(_format_output(selected, output=output.lower()))
+
+    raise typer.Exit(0 if report.get("ok") else 1)

--- a/Python/cli/mcp_cli/logs.py
+++ b/Python/cli/mcp_cli/logs.py
@@ -1,0 +1,86 @@
+"""Logging utilities for the MCP CLI."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from rich.console import Console
+from rich.logging import RichHandler
+
+__all__ = ["configure_logging", "get_logger"]
+
+_DEFAULT_JSONL = Path.home() / ".mcp-cli" / "events.jsonl"
+
+
+class _JsonlHandler(logging.Handler):
+    """Write log records as JSON lines to a file."""
+
+    def __init__(self, path: Path) -> None:
+        super().__init__()
+        self._path = path
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - filesystem IO
+        payload: Dict[str, Any] = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "level": record.levelname.lower(),
+            "msg": record.getMessage(),
+        }
+        for key in ("step", "tool", "request_id", "ok", "duration_ms"):
+            if hasattr(record, key):
+                payload[key] = getattr(record, key)
+        if record.exc_info:
+            payload["exc_info"] = logging.Formatter().formatException(record.exc_info)
+        with self._path.open("a", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False)
+            handle.write("\n")
+
+
+def _level_from_str(level: str) -> int:
+    mapping = {
+        "critical": logging.CRITICAL,
+        "error": logging.ERROR,
+        "warning": logging.WARNING,
+        "info": logging.INFO,
+        "debug": logging.DEBUG,
+        "trace": logging.NOTSET,
+    }
+    normalized = level.lower()
+    return mapping.get(normalized, logging.INFO)
+
+
+def configure_logging(level: str = "info", jsonl_path: Optional[Path] = None) -> logging.Logger:
+    """Configure structured logging for the CLI."""
+
+    logger = logging.getLogger("mcp_cli")
+    logger.setLevel(_level_from_str(level))
+    logger.propagate = False
+    logger.handlers.clear()
+
+    console = Console(stderr=True)
+    console_handler = RichHandler(
+        console=console,
+        show_time=False,
+        show_path=False,
+        markup=True,
+        enable_link_path=False,
+    )
+    console_handler.setLevel(logger.level)
+    formatter = logging.Formatter("%(message)s")
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+
+    jsonl_target = jsonl_path or _DEFAULT_JSONL
+    logger.addHandler(_JsonlHandler(jsonl_target))
+
+    return logger
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a child logger of the CLI root logger."""
+
+    return logging.getLogger("mcp_cli").getChild(name)

--- a/Python/cli/mcp_cli/mcp_client.py
+++ b/Python/cli/mcp_cli/mcp_client.py
@@ -1,0 +1,246 @@
+"""Synchronous TCP client for the Unreal MCP Python server."""
+
+from __future__ import annotations
+
+import json
+import socket
+import struct
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+from .logs import get_logger
+
+__all__ = ["MCPClient", "ProtocolError"]
+
+
+logger = get_logger("client")
+
+
+class ProtocolError(RuntimeError):
+    """Raised when a transport level error occurs."""
+
+    def __init__(self, code: str, message: str, details: Optional[Dict[str, Any]] = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.details = details or {}
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": False,
+            "error": {
+                "code": self.code,
+                "message": str(self),
+                "details": self.details,
+            },
+        }
+
+
+HEADER_SIZE = 4
+MAX_FRAME_SIZE = 4 * 1024 * 1024
+
+
+@dataclass
+class _Endpoint:
+    host: str
+    port: int
+
+
+def _parse_endpoint(server: str) -> _Endpoint:
+    if "//" in server:
+        server = server.split("//", 1)[1]
+    if ":" not in server:
+        host, port = server, 8765
+    else:
+        host, port_str = server.rsplit(":", 1)
+        port = int(port_str)
+    return _Endpoint(host or "127.0.0.1", port)
+
+
+def _monotonic_deadline(timeout: Optional[float]) -> Optional[float]:
+    import time
+
+    if timeout is None:
+        return None
+    return time.monotonic() + timeout
+
+
+def _remaining_time(deadline: Optional[float]) -> Optional[float]:
+    import time
+
+    if deadline is None:
+        return None
+    remaining = deadline - time.monotonic()
+    return max(0.0, remaining)
+
+
+def _read_exact(sock: socket.socket, size: int, timeout: Optional[float] = None) -> bytes:
+    if size <= 0:
+        return b""
+    deadline = _monotonic_deadline(timeout)
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining > 0:
+        chunk_timeout = _remaining_time(deadline)
+        try:
+            sock.settimeout(chunk_timeout)
+            chunk = sock.recv(remaining)
+        except socket.timeout as exc:  # pragma: no cover - depends on OS
+            raise ProtocolError("READ_TIMEOUT", "Timed out while reading from MCP server.") from exc
+        except OSError as exc:  # pragma: no cover - platform specific
+            raise ProtocolError("TRANSPORT_ERROR", f"Socket read failed: {exc}") from exc
+        if not chunk:
+            raise ProtocolError("CONNECTION_CLOSED", "Socket closed while reading frame.")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _write_all(sock: socket.socket, payload: bytes, timeout: Optional[float] = None) -> None:
+    if not payload:
+        return
+    deadline = _monotonic_deadline(timeout)
+    total_sent = 0
+    while total_sent < len(payload):
+        chunk_timeout = _remaining_time(deadline)
+        try:
+            sock.settimeout(chunk_timeout)
+            sent = sock.send(payload[total_sent:])
+        except socket.timeout as exc:  # pragma: no cover - depends on OS
+            raise ProtocolError("WRITE_TIMEOUT", "Timed out while sending frame to MCP server.") from exc
+        except OSError as exc:  # pragma: no cover
+            raise ProtocolError("TRANSPORT_ERROR", f"Socket write failed: {exc}") from exc
+        if sent == 0:
+            raise ProtocolError("CONNECTION_CLOSED", "Socket closed while sending frame.")
+        total_sent += sent
+
+
+def _write_frame(sock: socket.socket, payload: Dict[str, Any], timeout: Optional[float] = None) -> None:
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    if len(body) > MAX_FRAME_SIZE:
+        raise ProtocolError("FRAME_TOO_LARGE", "Frame exceeds maximum size.", {"length": len(body)})
+    header = struct.pack("<I", len(body))
+    _write_all(sock, header, timeout)
+    _write_all(sock, body, timeout)
+
+
+def _read_frame(sock: socket.socket, timeout: Optional[float] = None) -> Dict[str, Any]:
+    header = _read_exact(sock, HEADER_SIZE, timeout)
+    (length,) = struct.unpack("<I", header)
+    if length <= 0 or length > MAX_FRAME_SIZE:
+        raise ProtocolError("MALFORMED_FRAME", "Invalid frame length.", {"length": length})
+    payload = _read_exact(sock, length, timeout)
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ProtocolError("INVALID_JSON", "Received invalid JSON payload.") from exc
+
+
+class MCPClient:
+    """Client capable of sending tool invocations to the MCP server."""
+
+    def __init__(
+        self,
+        server: str,
+        *,
+        connect_timeout: float = 5.0,
+        read_timeout: float = 120.0,
+    ) -> None:
+        self._endpoint = _parse_endpoint(server)
+        self._connect_timeout = connect_timeout
+        self._read_timeout = read_timeout
+        self._sock: Optional[socket.socket] = None
+        self._session_id = str(uuid.uuid4())
+        self._handshake_ok = False
+
+    @property
+    def connected(self) -> bool:
+        return self._handshake_ok and self._sock is not None
+
+    def connect(self) -> Dict[str, Any]:
+        if self._sock:
+            self.close()
+        sock = socket.create_connection((self._endpoint.host, self._endpoint.port), timeout=self._connect_timeout)
+        sock.settimeout(None)
+        self._sock = sock
+        handshake = {
+            "type": "handshake",
+            "client": "mcp-cli",
+            "sessionId": self._session_id,
+            "protocolVersion": 1,
+        }
+        _write_frame(sock, handshake, timeout=self._connect_timeout)
+        ack = _read_frame(sock, timeout=self._connect_timeout)
+        if ack.get("type") != "handshake/ack" or not ack.get("ok", False):
+            raise ProtocolError("HANDSHAKE_FAILED", "MCP server rejected handshake.", {"response": ack})
+        self._handshake_ok = True
+        logger.debug("Handshake accepted: %s", ack)
+        return ack
+
+    def close(self) -> None:
+        if self._sock:
+            try:
+                self._sock.close()
+            except OSError:  # pragma: no cover - best effort
+                pass
+        self._sock = None
+        self._handshake_ok = False
+
+    def call_tool(
+        self,
+        tool: str,
+        params: Optional[Dict[str, Any]] = None,
+        *,
+        meta: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        if not self._handshake_ok or not self._sock:
+            self.connect()
+        request_id = str(uuid.uuid4())
+        payload = {
+            "type": "tool/call",
+            "tool": tool,
+            "params": params or {},
+            "requestId": request_id,
+            "idempotencyKey": request_id,
+            "meta": meta or {},
+        }
+        attempt_timeout = timeout or self._read_timeout
+        _write_frame(self._sock, payload, timeout=self._connect_timeout)
+        response = _read_frame(self._sock, timeout=attempt_timeout)
+        return response
+
+    def call_with_retry(
+        self,
+        tool: str,
+        params: Optional[Dict[str, Any]] = None,
+        *,
+        meta: Optional[Dict[str, Any]] = None,
+        attempts: int = 1,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        def _invoke() -> Dict[str, Any]:
+            try:
+                return self.call_tool(tool, params, meta=meta, timeout=timeout)
+            except (ProtocolError, OSError):
+                self.close()
+                raise
+
+        if attempts <= 1:
+            return _invoke()
+
+        retry = Retrying(
+            retry=retry_if_exception_type((ProtocolError, OSError)),
+            stop=stop_after_attempt(attempts),
+            wait=wait_exponential(multiplier=0.5, min=0.5, max=5.0),
+            reraise=True,
+        )
+        for attempt in retry:
+            with attempt:
+                return _invoke()
+        raise AssertionError("tenacity did not return a result")
+
+
+__all__ = ["MCPClient", "ProtocolError"]

--- a/Python/cli/mcp_cli/recipes.py
+++ b/Python/cli/mcp_cli/recipes.py
@@ -1,0 +1,401 @@
+"""Recipe loading and execution utilities."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import jmespath
+import yaml
+from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_exponential, wait_random
+
+from .logs import get_logger
+from .mcp_client import MCPClient, ProtocolError
+from .schema import SchemaError, StepSpec, ValidatedRecipe, select_recipe, validate_recipe
+
+__all__ = [
+    "LoadedRecipe",
+    "RecipeExecutor",
+    "load_recipe_file",
+    "merge_variables",
+    "render_value",
+]
+
+logger = get_logger("recipes")
+
+
+@dataclass
+class LoadedRecipe:
+    recipe: ValidatedRecipe
+    source_path: Path
+    document: dict
+
+
+@dataclass
+class StepResult:
+    name: str
+    ok: bool
+    response: Dict[str, Any]
+    duration: float
+    skipped: bool = False
+    saved_path: Optional[Path] = None
+
+
+def load_recipe_file(path: Path, recipe_name: Optional[str] = None) -> LoadedRecipe:
+    resolved_path = path.resolve()
+    if not resolved_path.exists():
+        raise FileNotFoundError(f"Recipe file not found: {resolved_path}")
+    with resolved_path.open("r", encoding="utf-8") as handle:
+        document = yaml.safe_load(handle) or {}
+    if not isinstance(document, dict):
+        raise SchemaError("Recipe file must contain a mapping at the top level")
+    name, recipe_body = select_recipe(document, recipe_name=recipe_name)
+    validated = validate_recipe(recipe_body, name=name)
+    return LoadedRecipe(recipe=validated, source_path=resolved_path, document=document)
+
+
+def merge_variables(
+    recipe_vars: Dict[str, str],
+    cli_vars: Dict[str, str],
+    file_vars: Dict[str, Any],
+) -> Dict[str, Any]:
+    merged: Dict[str, Any] = {key: value for key, value in os.environ.items()}
+    merged.update(recipe_vars)
+    merged.update(file_vars)
+    merged.update(cli_vars)
+    return merged
+
+
+_ENV_PATTERN = re.compile(r"\$\{([^{}]+)\}")
+_STEP_PATTERN = re.compile(r"\$\{\{([^{}]+)\}\}")
+
+
+def _resolve_env_expression(expr: str, variables: Dict[str, Any]) -> str:
+    if ":-" in expr:
+        key, default = expr.split(":-", 1)
+        key = key.strip()
+        default_value = default
+    else:
+        key, default_value = expr, None
+    key = key.strip()
+    if key in variables and variables[key] is not None:
+        return str(variables[key])
+    if key in os.environ:
+        return os.environ[key]
+    if default_value is not None:
+        return str(default_value)
+    return ""
+
+
+def _replace_env_strings(value: str, variables: Dict[str, Any]) -> str:
+    def repl(match: re.Match[str]) -> str:
+        expr = match.group(1)
+        return _resolve_env_expression(expr, variables)
+
+    return _ENV_PATTERN.sub(repl, value)
+
+
+def _replace_step_references(value: str, context: Dict[str, Any]) -> str:
+    def repl(match: re.Match[str]) -> str:
+        expression = match.group(1).strip()
+        try:
+            result = jmespath.search(expression, context)
+        except Exception as exc:
+            raise SchemaError(f"Failed to evaluate expression '{expression}': {exc}") from exc
+        if result is None:
+            return ""
+        if isinstance(result, (dict, list)):
+            return json.dumps(result)
+        return str(result)
+
+    return _STEP_PATTERN.sub(repl, value)
+
+
+def render_value(value: Any, variables: Dict[str, Any], context: Dict[str, Any]) -> Any:
+    if isinstance(value, str):
+        replaced = _replace_step_references(value, context)
+        replaced = _replace_env_strings(replaced, variables)
+        return replaced
+    if isinstance(value, list):
+        return [render_value(item, variables, context) for item in value]
+    if isinstance(value, dict):
+        return {key: render_value(val, variables, context) for key, val in value.items()}
+    return value
+
+
+def _load_params_from_file(base_dir: Path, file_path: str) -> Dict[str, Any]:
+    resolved_path = (base_dir / file_path).resolve()
+    if not resolved_path.exists():
+        raise FileNotFoundError(f"Params file not found: {resolved_path}")
+    with resolved_path.open("r", encoding="utf-8") as handle:
+        text = handle.read()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return yaml.safe_load(text)
+
+
+def _evaluate_condition(value: Any, variables: Dict[str, Any], context: Dict[str, Any]) -> bool:
+    if value is None:
+        return True
+    evaluated = render_value(value, variables, context)
+    if isinstance(evaluated, bool):
+        return evaluated
+    if isinstance(evaluated, (int, float)):
+        return bool(evaluated)
+    if isinstance(evaluated, str):
+        normalized = evaluated.strip().lower()
+        if normalized in {"", "true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+        return bool(normalized)
+    return bool(evaluated)
+
+
+def _step_retry_config(step_raw: dict, default_attempts: int) -> Tuple[int, float, float]:
+    retry_cfg = step_raw.get("retry")
+    attempts = default_attempts
+    backoff = 1.0
+    jitter = 0.0
+    if isinstance(retry_cfg, dict):
+        max_attempts = retry_cfg.get("max_attempts")
+        if isinstance(max_attempts, int) and max_attempts > 0:
+            attempts = max_attempts
+        backoff_val = retry_cfg.get("backoff_sec")
+        if isinstance(backoff_val, (int, float)) and backoff_val > 0:
+            backoff = float(backoff_val)
+        jitter_val = retry_cfg.get("jitter")
+        if isinstance(jitter_val, (int, float)) and jitter_val >= 0:
+            jitter = float(jitter_val)
+    return attempts, backoff, jitter
+
+
+class RecipeExecutor:
+    def __init__(
+        self,
+        client: MCPClient,
+        loaded: LoadedRecipe,
+        *,
+        variables: Dict[str, Any],
+    ) -> None:
+        self.client = client
+        self.loaded = loaded
+        self.variables = variables
+        self.context: Dict[str, Any] = {"steps": {}, "vars": variables}
+        self.base_dir = loaded.source_path.parent
+        self._step_map: Dict[str, StepSpec] = {step.name: step for step in loaded.recipe.steps}
+
+    def plan(self) -> List[str]:
+        from graphlib import TopologicalSorter
+
+        sorter = TopologicalSorter()
+        for step in self.loaded.recipe.steps:
+            sorter.add(step.name, *step.needs)
+        return list(sorter.static_order())
+
+    def execute(
+        self,
+        *,
+        dry_run: bool = False,
+        default_retry: int = 1,
+        parallelism: int = 1,
+        continue_on_error: bool = False,
+        default_timeout: Optional[float] = None,
+        allow_save: bool = True,
+    ) -> Dict[str, Any]:
+        from graphlib import TopologicalSorter
+
+        sorter = TopologicalSorter()
+        for step in self.loaded.recipe.steps:
+            sorter.add(step.name, *step.needs)
+        sorter.prepare()
+
+        executor = ThreadPoolExecutor(max_workers=max(1, parallelism))
+        futures: Dict[Future[StepResult], str] = {}
+        results: Dict[str, StepResult] = {}
+        failed = False
+        audit_actions: List[Any] = []
+        audit_diffs: List[Any] = []
+
+        try:
+            while True:
+                ready = list(sorter.get_ready())
+                if not ready and not futures:
+                    break
+                for name in ready:
+                    step_spec = self._step_map[name]
+                    step_context = self.context
+                    condition = _evaluate_condition(step_spec.raw.get("when"), self.variables, step_context)
+                    if not condition:
+                        logger.info("Skipping step %s (condition false)", name)
+                        result = StepResult(name=name, ok=True, response={}, duration=0.0, skipped=True)
+                        results[name] = result
+                        self.context["steps"][name] = {"skipped": True, "ok": True, "result": {}}
+                        sorter.done(name)
+                        continue
+                    dependency_states = [results[dep] for dep in step_spec.needs if dep in results]
+                    if any(not dep_result.ok for dep_result in dependency_states):
+                        logger.warning("Skipping step %s because dependency failed", name)
+                        result = StepResult(name=name, ok=False, response={}, duration=0.0, skipped=True)
+                        results[name] = result
+                        self.context["steps"][name] = {"skipped": True, "ok": False, "result": {}}
+                        failed = True
+                        sorter.done(name)
+                        continue
+
+                    future = executor.submit(
+                        self._run_step,
+                        step_spec,
+                        dry_run,
+                        default_retry,
+                        default_timeout,
+                        allow_save,
+                    )
+                    futures[future] = name
+
+                if not futures:
+                    continue
+
+                done, _ = wait(futures.keys(), return_when=FIRST_COMPLETED)
+                abort = False
+                for future in done:
+                    name = futures.pop(future)
+                    try:
+                        step_result = future.result()
+                    except Exception as exc:  # pragma: no cover - defensive
+                        logger.exception("Step %s raised an unexpected error", name)
+                        step_result = StepResult(name=name, ok=False, response={"ok": False, "error": {"code": "INTERNAL_ERROR", "message": str(exc)}}, duration=0.0)
+                    results[name] = step_result
+                    self.context["steps"][name] = {
+                        "ok": step_result.ok,
+                        "skipped": step_result.skipped,
+                        "result": step_result.response,
+                    }
+                    sorter.done(name)
+                    if not step_result.ok and not step_result.skipped:
+                        failed = True
+                        if not continue_on_error:
+                            logger.error("Step %s failed; aborting remaining steps", name)
+                            for pending in futures:
+                                pending.cancel()
+                            futures.clear()
+                            abort = True
+                            break
+                        logger.warning("Continuing despite failure in %s", name)
+                    audit = step_result.response.get("audit") if isinstance(step_result.response, dict) else None
+                    if isinstance(audit, dict):
+                        actions = audit.get("actions")
+                        if isinstance(actions, list):
+                            audit_actions.extend(actions)
+                        diffs = audit.get("diffs")
+                        if isinstance(diffs, list):
+                            audit_diffs.extend(diffs)
+                if abort:
+                    break
+        finally:
+            executor.shutdown(wait=True)
+
+        for name in self._step_map:
+            if name not in results:
+                results[name] = StepResult(name=name, ok=False, response={}, duration=0.0, skipped=True)
+                failed = True
+
+        summary = {
+            "ok": not failed,
+            "steps": {
+                name: {
+                    "ok": result.ok,
+                    "skipped": result.skipped,
+                    "durSec": round(result.duration, 3),
+                    **({"save_as": str(result.saved_path)} if result.saved_path else {}),
+                }
+                for name, result in results.items()
+            },
+            "audit": {
+                "actions": audit_actions,
+                "diffs": audit_diffs,
+            },
+            "plan": self.plan(),
+        }
+        return summary
+
+    def _run_step(
+        self,
+        step: StepSpec,
+        dry_run: bool,
+        default_retry: int,
+        default_timeout: Optional[float],
+        allow_save: bool,
+    ) -> StepResult:
+        params: Any = step.params
+        path_value = step.params_file
+        if path_value:
+            rendered_path = render_value(path_value, self.variables, self.context)
+            if not isinstance(rendered_path, str):
+                raise SchemaError(f"Step {step.name} params_file must resolve to a string path")
+            params = _load_params_from_file(self.base_dir, rendered_path)
+        params = render_value(params, self.variables, self.context) if params is not None else {}
+        if dry_run and isinstance(params, dict) and "DryRun" not in params:
+            params = dict(params)
+            params.setdefault("DryRun", True)
+        meta = {
+            "step": step.name,
+            "dryRun": dry_run,
+            "vars": {k: v for k, v in self.variables.items() if isinstance(k, str)},
+        }
+        timeout = default_timeout
+        timeout_raw = step.raw.get("timeout_sec")
+        if isinstance(timeout_raw, (int, float)) and timeout_raw > 0:
+            timeout = float(timeout_raw)
+
+        attempts, backoff, jitter = _step_retry_config(step.raw, default_retry)
+
+        start = time.time()
+
+        def invoke() -> Dict[str, Any]:
+            return self.client.call_tool(step.tool, params, meta=meta, timeout=timeout)
+
+        try:
+            if attempts <= 1:
+                response = invoke()
+            else:
+                waits = wait_exponential(multiplier=backoff, min=backoff, max=max(backoff * 4, backoff))
+                if jitter > 0:
+                    waits = waits + wait_random(0, jitter)
+                retry = Retrying(
+                    retry=retry_if_exception_type((ProtocolError, OSError)),
+                    stop=stop_after_attempt(attempts),
+                    wait=waits,
+                    reraise=True,
+                )
+                for attempt in retry:
+                    with attempt:
+                        response = invoke()
+                        break
+            duration = time.time() - start
+            ok = bool(response.get("ok", False)) if isinstance(response, dict) else False
+            saved_path = None
+            save_as = step.raw.get("save_as")
+            if allow_save and isinstance(save_as, str):
+                save_path = (self.base_dir / save_as).resolve()
+                save_path.parent.mkdir(parents=True, exist_ok=True)
+                with save_path.open("w", encoding="utf-8") as handle:
+                    json.dump(response, handle, indent=2)
+                saved_path = save_path
+            return StepResult(name=step.name, ok=ok, response=response, duration=duration, saved_path=saved_path)
+        except Exception as exc:
+            duration = time.time() - start
+            logger.error("Step %s raised exception: %s", step.name, exc)
+            return StepResult(
+                name=step.name,
+                ok=False,
+                response={"ok": False, "error": {"code": "EXCEPTION", "message": str(exc)}},
+                duration=duration,
+            )

--- a/Python/cli/mcp_cli/schema.py
+++ b/Python/cli/mcp_cli/schema.py
@@ -1,0 +1,141 @@
+"""Schema helpers for recipe validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Set
+
+__all__ = ["SchemaError", "ValidatedRecipe", "StepSpec", "validate_recipe", "select_recipe"]
+
+
+class SchemaError(ValueError):
+    """Raised when the recipe definition is invalid."""
+
+
+@dataclass
+class StepSpec:
+    name: str
+    tool: str
+    params: Optional[dict]
+    params_file: Optional[str]
+    needs: List[str]
+    raw: dict
+
+
+@dataclass
+class ValidatedRecipe:
+    name: str
+    version: int
+    steps: List[StepSpec]
+    vars: Dict[str, str]
+
+
+def _ensure_unique_steps(steps: Iterable[StepSpec]) -> None:
+    seen: Set[str] = set()
+    for step in steps:
+        if step.name in seen:
+            raise SchemaError(f"Duplicate step name: {step.name}")
+        seen.add(step.name)
+
+
+def _validate_dependencies(steps: List[StepSpec]) -> None:
+    step_names = {step.name for step in steps}
+    for step in steps:
+        for dep in step.needs:
+            if dep not in step_names:
+                raise SchemaError(f"Step '{step.name}' depends on unknown step '{dep}'")
+    # Simple cycle detection using DFS
+    graph = {step.name: set(step.needs) for step in steps}
+    visiting: Set[str] = set()
+    visited: Set[str] = set()
+
+    def dfs(node: str) -> None:
+        if node in visiting:
+            raise SchemaError(f"Cycle detected involving step '{node}'")
+        if node in visited:
+            return
+        visiting.add(node)
+        for neighbor in graph[node]:
+            dfs(neighbor)
+        visiting.remove(node)
+        visited.add(node)
+
+    for step in steps:
+        dfs(step.name)
+
+
+def validate_recipe(recipe: dict, *, name: str = "default") -> ValidatedRecipe:
+    if not isinstance(recipe, dict):
+        raise SchemaError("Recipe definition must be a mapping")
+    version = recipe.get("version")
+    if version != 1:
+        raise SchemaError("Only recipe version=1 is supported")
+    raw_steps = recipe.get("steps")
+    if not isinstance(raw_steps, list) or not raw_steps:
+        raise SchemaError("Recipe must define at least one step")
+
+    steps: List[StepSpec] = []
+    for index, item in enumerate(raw_steps):
+        if not isinstance(item, dict):
+            raise SchemaError(f"Step at index {index} must be a mapping")
+        step_name = item.get("name")
+        tool_name = item.get("tool")
+        params = item.get("params")
+        params_file = item.get("params_file")
+        if not isinstance(step_name, str) or not step_name:
+            raise SchemaError(f"Step at index {index} is missing a valid name")
+        if not isinstance(tool_name, str) or not tool_name:
+            raise SchemaError(f"Step '{step_name}' must define a tool")
+        if params is not None and params_file is not None:
+            raise SchemaError(f"Step '{step_name}' cannot define both params and params_file")
+        if params is None and params_file is None:
+            raise SchemaError(f"Step '{step_name}' must define params or params_file")
+        if params is not None and not isinstance(params, dict):
+            raise SchemaError(f"Step '{step_name}' params must be a mapping")
+        if params_file is not None and not isinstance(params_file, str):
+            raise SchemaError(f"Step '{step_name}' params_file must be a string path")
+        needs_raw = item.get("needs", [])
+        if needs_raw is None:
+            needs = []
+        elif isinstance(needs_raw, list) and all(isinstance(x, str) for x in needs_raw):
+            needs = list(needs_raw)
+        else:
+            raise SchemaError(f"Step '{step_name}' needs must be a list of step names")
+        steps.append(StepSpec(step_name, tool_name, params, params_file, needs, dict(item)))
+
+    _ensure_unique_steps(steps)
+    _validate_dependencies(steps)
+
+    vars_section = recipe.get("vars", {})
+    if not isinstance(vars_section, dict):
+        raise SchemaError("Recipe vars must be a mapping")
+    cast_vars: Dict[str, str] = {}
+    for key, value in vars_section.items():
+        if not isinstance(key, str):
+            raise SchemaError("Recipe variable names must be strings")
+        cast_vars[key] = str(value)
+
+    return ValidatedRecipe(name=name, version=version, steps=steps, vars=cast_vars)
+
+
+def select_recipe(document: dict, *, recipe_name: Optional[str] = None) -> tuple[str, dict]:
+    """Select the recipe definition from a YAML document."""
+
+    if recipe_name:
+        recipes = document.get("recipes")
+        if not isinstance(recipes, dict):
+            raise SchemaError("Document does not define named recipes")
+        if recipe_name not in recipes:
+            raise SchemaError(f"Recipe '{recipe_name}' not found in document")
+        selected = recipes[recipe_name]
+        return recipe_name, selected
+
+    if "steps" in document:
+        return recipe_name or "default", document
+
+    recipes = document.get("recipes")
+    if isinstance(recipes, dict) and len(recipes) == 1:
+        (key, value), *_ = recipes.items()
+        return key, value
+
+    raise SchemaError("Unable to determine which recipe to execute; specify name with #recipe")

--- a/Python/cli/pyproject.toml
+++ b/Python/cli/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "mcp-cli"
+version = "0.1.0"
+description = "Command line interface for the Unreal MCP server"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "typer[all]>=0.12.3",
+    "PyYAML>=6.0.1",
+    "jmespath>=1.0.1",
+    "tenacity>=8.2.3",
+    "rich>=13.7.1",
+]
+
+[project.scripts]
+mcp = "mcp_cli.__main__:main"
+
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["mcp_cli"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,28 @@
 - **Outils de santé** : tool read-only `mcp.health` retourne versions, uptime, flags d’enforcement, RTT et infos plugin.
 - **Réglages** : nouveau `LogLevel`, `EnableJsonLogs` et boutons Diagnostics (ouvrir events/metrics log, tail live).
 
+## 🖥️ CLI locale (`mcp`)
+Un binaire `mcp` (Typer) est fourni pour piloter le serveur MCP sans passer par un agent externe.
+
+```bash
+# Lancer un tool directement
+mcp run level.save_open --params-json '{"modifiedOnly": true}'
+
+# Exécuter une recette YAML (pipeline DAG)
+mcp recipe run ./.mcp/pipelines/content_cleanup.yaml --vars GAME_ROOT=/Game/Core
+
+# Valider / dry-run une recette
+mcp recipe test ./.mcp/pipelines/content_cleanup.yaml --dry-run
+```
+
+| Commande          | Description                                      |
+|-------------------|--------------------------------------------------|
+| `mcp run`         | Exécute un tool MCP unique avec paramètres JSON  |
+| `mcp recipe run`  | Exécute un pipeline YAML (steps dépendants, DAG) |
+| `mcp recipe test` | Valide la recette, affiche le plan, option dry-run |
+
+Fonctionnalités transverses : `--dry-run`, `--retry`, `--parallel`, `--vars`/`--vars-file`, `--select` (JMESPath), `--output json|yaml`, `--timeout`, `--log-level`, `--server`.
+
 ## 🧰 Outils exposés (MCP Tools)
 
 ### Lecture (toujours autorisées)


### PR DESCRIPTION
## Summary
- add a Typer-based `mcp` CLI with tool execution, recipe pipelines, dry-run, retry, parallelism, and result filtering
- implement a TCP client, recipe planner/executor, and structured logging helpers for the CLI
- document CLI installation, usage examples, and recipe format in the READMEs

## Testing
- python -m compileall Python/cli

------
https://chatgpt.com/codex/tasks/task_e_68db9a4e1fcc832f8c2999d90bf97cdc