### PR TITLE
feat(security): enforce policy limits and audit signing on server

### DIFF
--- a/Python/.secrets.example.env
+++ b/Python/.secrets.example.env
@@ -1,0 +1,8 @@
+# Example secrets for the MCP Python server (chmod 600 before use)
+#
+# Copy this file to `.secrets.env`, adjust the values, then source it or load via
+# your process manager (systemd `EnvironmentFile`, Docker secrets, etc.).
+
+# Shared secret used to sign audit payloads (HMAC-SHA256)
+MCP_AUDIT_SECRET="change-me-to-a-long-random-string"
+

--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -10,7 +10,9 @@ dependencies = [
   "uvicorn",
   "fastapi",
   "pydantic>=2.6.1",
-  "requests"
+  "requests",
+  "pyyaml",
+  "jsonschema"
 ]
 
 [build-system]

--- a/Python/security/audit_sign.py
+++ b/Python/security/audit_sign.py
@@ -1,0 +1,77 @@
+"""Audit log signing helpers."""
+
+from __future__ import annotations
+
+import base64
+import hmac
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
+from threading import RLock
+from typing import Dict, Optional
+
+
+def _canonicalize_payload(payload: Dict[str, object]) -> bytes:
+    import json
+
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+@dataclass
+class AuditRecord:
+    request_id: str
+    tool: str
+    payload: Dict[str, object]
+
+
+class AuditSigner:
+    def __init__(self, secret: Optional[str]) -> None:
+        self.secret = secret.encode("utf-8") if secret else None
+        self._lock = RLock()
+        self._recent: Dict[str, float] = {}
+        self.ttl = 3600.0
+
+    def is_available(self) -> bool:
+        return self.secret is not None
+
+    def sign(self, record: AuditRecord) -> Optional[Dict[str, str]]:
+        if not self.secret:
+            return None
+        payload = {"requestId": record.request_id, "tool": record.tool, **record.payload}
+        server_ts = datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
+        payload_with_ts = {**payload, "serverTs": server_ts}
+        canonical = _canonicalize_payload(payload_with_ts)
+        signature = base64.b64encode(hmac.new(self.secret, canonical, sha256).digest()).decode("ascii")
+        nonce = str(uuid.uuid4())
+        timestamp = time.time()
+        with self._lock:
+            self._prune_locked(timestamp)
+            self._recent[nonce] = timestamp
+        return {"auditSig": signature, "nonce": nonce, "serverTs": server_ts}
+
+    def verify_nonce(self, nonce: str) -> bool:
+        with self._lock:
+            timestamp = time.time()
+            self._prune_locked(timestamp)
+            if nonce in self._recent:
+                return False
+            self._recent[nonce] = timestamp
+        return True
+
+    def _prune_locked(self, now: float) -> None:
+        expired = [key for key, ts in self._recent.items() if now - ts > self.ttl]
+        for key in expired:
+            self._recent.pop(key, None)
+
+
+def load_secret_from_env(env_var: str) -> Optional[str]:
+    value = os.getenv(env_var)
+    if value:
+        return value.strip()
+    return None
+
+
+__all__ = ["AuditRecord", "AuditSigner", "load_secret_from_env"]

--- a/Python/security/policy.py
+++ b/Python/security/policy.py
@@ -1,0 +1,182 @@
+"""Policy enforcement utilities for the Unreal MCP server."""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from threading import RLock
+from typing import Dict, Iterable, List, Optional
+
+import yaml
+
+
+@dataclass
+class RoleRules:
+    """Allow and deny patterns for a specific role."""
+
+    allow: List[str] = field(default_factory=list)
+    deny: List[str] = field(default_factory=list)
+
+    def evaluate(self, tool: str) -> bool:
+        """Return ``True`` when ``tool`` is permitted for the role."""
+
+        normalized_tool = tool or ""
+        explicit_allow = False
+
+        patterns = self.allow + [f"!{pattern}" for pattern in self.deny]
+        if not patterns:
+            return False
+
+        for pattern in patterns:
+            pattern = pattern.strip()
+            if not pattern:
+                continue
+            is_deny = pattern.startswith("!")
+            if is_deny:
+                pattern = pattern[1:].strip()
+            if not pattern:
+                continue
+            if fnmatch.fnmatchcase(normalized_tool, pattern):
+                if is_deny:
+                    return False
+                explicit_allow = True
+        return explicit_allow
+
+
+@dataclass
+class PolicyLimits:
+    rate_per_minute_global: int = 120
+    rate_per_minute_per_tool: int = 30
+    request_size_kb: int = 512
+    array_items_max: int = 10_000
+
+
+@dataclass
+class PathRules:
+    allowed: List[str] = field(default_factory=list)
+    forbidden: List[str] = field(default_factory=list)
+
+
+@dataclass
+class AuditRules:
+    require_signature: bool = True
+    hmac_secret_env: str = "MCP_AUDIT_SECRET"
+
+
+@dataclass
+class Policy:
+    roles: Dict[str, RoleRules] = field(default_factory=dict)
+    limits: PolicyLimits = field(default_factory=PolicyLimits)
+    paths: PathRules = field(default_factory=PathRules)
+    audit: AuditRules = field(default_factory=AuditRules)
+
+    def role_rules(self, role: str) -> RoleRules:
+        return self.roles.get(role, RoleRules())
+
+    def is_tool_allowed(self, role: str, tool: str) -> bool:
+        rules = self.role_rules(role)
+        return rules.evaluate(tool)
+
+
+class PolicyLoader:
+    """Load and cache policy documents from disk."""
+
+    def __init__(self, policy_path: Optional[Path] = None) -> None:
+        self.policy_path = policy_path or self._resolve_from_env()
+        self._policy: Optional[Policy] = None
+        self._lock = RLock()
+
+    def _resolve_from_env(self) -> Optional[Path]:
+        env_path = os.getenv("MCP_POLICY_PATH")
+        if env_path:
+            return Path(env_path).expanduser().resolve()
+        return None
+
+    def load(self, force: bool = False) -> Policy:
+        with self._lock:
+            if self._policy is not None and not force:
+                return self._policy
+            data = self._read_policy()
+            self._policy = self._parse_policy(data)
+            return self._policy
+
+    def _read_policy(self) -> Dict[str, object]:
+        if self.policy_path and self.policy_path.exists():
+            with self.policy_path.open("r", encoding="utf-8") as handle:
+                return yaml.safe_load(handle) or {}
+        return {}
+
+    def _parse_policy(self, data: Dict[str, object]) -> Policy:
+        roles_data = data.get("roles", {}) if isinstance(data, dict) else {}
+        roles: Dict[str, RoleRules] = {}
+        for name, payload in roles_data.items():
+            if isinstance(payload, dict):
+                allow = [str(p) for p in payload.get("allow", []) if isinstance(p, str)]
+                deny = [str(p) for p in payload.get("deny", []) if isinstance(p, str)]
+                roles[name] = RoleRules(allow=allow, deny=deny)
+
+        limits_data = data.get("limits", {}) if isinstance(data, dict) else {}
+        limits = PolicyLimits(
+            rate_per_minute_global=int(limits_data.get("rate_per_minute_global", 120)),
+            rate_per_minute_per_tool=int(limits_data.get("rate_per_minute_per_tool", 30)),
+            request_size_kb=int(limits_data.get("request_size_kb", 512)),
+            array_items_max=int(limits_data.get("array_items_max", 10_000)),
+        )
+
+        paths_data = data.get("paths", {}) if isinstance(data, dict) else {}
+        paths = PathRules(
+            allowed=[str(p) for p in paths_data.get("allowed", []) if isinstance(p, str)],
+            forbidden=[str(p) for p in paths_data.get("forbidden", []) if isinstance(p, str)],
+        )
+
+        audit_data = data.get("audit", {}) if isinstance(data, dict) else {}
+        audit = AuditRules(
+            require_signature=bool(audit_data.get("require_signature", True)),
+            hmac_secret_env=str(audit_data.get("hmac_secret_env", "MCP_AUDIT_SECRET")),
+        )
+
+        return Policy(roles=roles, limits=limits, paths=paths, audit=audit)
+
+
+def normalize_patterns(patterns: Iterable[str]) -> List[str]:
+    normalized: List[str] = []
+    for pattern in patterns:
+        pattern = str(pattern).strip()
+        if pattern:
+            normalized.append(pattern)
+    return normalized
+
+
+def evaluate_patterns(patterns: Iterable[str], target: str) -> bool:
+    """Evaluate allow/deny patterns in order for *target*.
+
+    Patterns prefixed with ``!`` act as explicit denies and take precedence.
+    The evaluation returns ``True`` when there is at least one matching allow
+    and no matching deny.
+    """
+
+    normalized_patterns = normalize_patterns(patterns)
+    allowed = False
+    for pattern in normalized_patterns:
+        negate = pattern.startswith("!")
+        candidate = pattern[1:].strip() if negate else pattern
+        if not candidate:
+            continue
+        if fnmatch.fnmatchcase(target, candidate):
+            if negate:
+                return False
+            allowed = True
+    return allowed
+
+
+__all__ = [
+    "AuditRules",
+    "PathRules",
+    "Policy",
+    "PolicyLimits",
+    "PolicyLoader",
+    "RoleRules",
+    "evaluate_patterns",
+]

--- a/Python/security/rate_limit.py
+++ b/Python/security/rate_limit.py
@@ -1,0 +1,46 @@
+"""Token bucket rate limiting helpers."""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from typing import Deque, Dict, Tuple
+
+
+@dataclass
+class RateLimitConfig:
+    per_minute_global: int
+    per_minute_tool: int
+
+
+class RateLimiter:
+    def __init__(self, config: RateLimitConfig) -> None:
+        self.config = config
+        self.window = 60.0
+        self.global_hits: Deque[float] = deque()
+        self.tool_hits: Dict[str, Deque[float]] = defaultdict(deque)
+
+    def _prune(self, hits: Deque[float], now: float) -> None:
+        while hits and now - hits[0] > self.window:
+            hits.popleft()
+
+    def check(self, tool: str) -> Tuple[bool, float]:
+        now = time.time()
+        self._prune(self.global_hits, now)
+        self._prune(self.tool_hits[tool], now)
+
+        if len(self.global_hits) >= self.config.per_minute_global:
+            retry = max(0.0, self.window - (now - self.global_hits[0]))
+            return False, retry
+
+        if len(self.tool_hits[tool]) >= self.config.per_minute_tool:
+            retry = max(0.0, self.window - (now - self.tool_hits[tool][0]))
+            return False, retry
+
+        self.global_hits.append(now)
+        self.tool_hits[tool].append(now)
+        return True, 0.0
+
+
+__all__ = ["RateLimitConfig", "RateLimiter"]

--- a/Python/security/sandbox.py
+++ b/Python/security/sandbox.py
@@ -1,0 +1,50 @@
+"""Filesystem sandbox helpers for the Unreal MCP server."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable
+
+
+def _normalize(path: Path) -> Path:
+    try:
+        resolved = path.resolve(strict=False)
+    except RuntimeError:
+        resolved = path
+    if os.name == "nt":
+        return Path(str(resolved).replace("\\", "/").lower())
+    return resolved
+
+
+def normalize_path(path: str) -> Path:
+    """Return a canonical Path for ``path`` suitable for comparisons."""
+
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        candidate = (Path.cwd() / candidate).resolve()
+    return _normalize(candidate)
+
+
+def is_within(path: Path, roots: Iterable[str]) -> bool:
+    normalized_path = normalize_path(str(path))
+    for root in roots:
+        root_path = normalize_path(root)
+        try:
+            normalized_path.relative_to(root_path)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def is_path_allowed(path: str, allowed_roots: Iterable[str], forbidden_roots: Iterable[str]) -> bool:
+    normalized = normalize_path(path)
+    if forbidden_roots and is_within(normalized, forbidden_roots):
+        return False
+    if not allowed_roots:
+        return True
+    return is_within(normalized, allowed_roots)
+
+
+__all__ = ["is_path_allowed", "normalize_path"]

--- a/Python/security/schema_registry.py
+++ b/Python/security/schema_registry.py
@@ -1,0 +1,54 @@
+"""JSON Schema registry for sensitive MCP tools."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+try:
+    import jsonschema
+except ImportError:  # pragma: no cover - jsonschema is an optional dependency
+    jsonschema = None  # type: ignore
+
+
+SCHEMAS: Dict[str, Dict[str, Any]] = {
+    "asset.batch_import": {
+        "type": "object",
+        "properties": {
+            "files": {
+                "type": "array",
+                "items": {"type": "object"},
+                "maxItems": 10000,
+            },
+            "confirm": {"type": "boolean"},
+        },
+        "required": ["files"],
+        "additionalProperties": True,
+    },
+    "sequence.create": {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "path": {"type": "string"},
+        },
+        "required": ["name", "path"],
+        "additionalProperties": False,
+    },
+}
+
+
+def get_schema(tool: str) -> Optional[Dict[str, Any]]:
+    return SCHEMAS.get(tool)
+
+
+def validate(tool: str, params: Dict[str, Any]) -> Optional[str]:
+    schema = get_schema(tool)
+    if not schema or not jsonschema:
+        return None
+    try:
+        jsonschema.validate(instance=params, schema=schema)  # type: ignore[arg-type]
+    except Exception as exc:  # pragma: no cover - error path
+        return str(exc)
+    return None
+
+
+__all__ = ["get_schema", "validate"]

--- a/Python/server.py
+++ b/Python/server.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import platform
 import time
+import uuid
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from mcp.server.fastmcp import Context, FastMCP
@@ -11,6 +14,192 @@ from mcp.server.fastmcp import Context, FastMCP
 from automation_specs import run_specs
 from gauntlet import run_gauntlet
 from uat import run_buildcookrun
+from security.audit_sign import AuditRecord, AuditSigner, load_secret_from_env
+from security.policy import PolicyLoader
+from security.rate_limit import RateLimitConfig, RateLimiter
+from security.sandbox import is_path_allowed
+from security.schema_registry import validate as validate_schema
+
+
+_POLICY_LOADER = PolicyLoader()
+_CURRENT_POLICY = _POLICY_LOADER.load()
+_RATE_LIMITER = RateLimiter(
+    RateLimitConfig(
+        per_minute_global=_CURRENT_POLICY.limits.rate_per_minute_global,
+        per_minute_tool=_CURRENT_POLICY.limits.rate_per_minute_per_tool,
+    )
+)
+_AUDIT_SECRET_VALUE = (
+    load_secret_from_env(_CURRENT_POLICY.audit.hmac_secret_env)
+    if _CURRENT_POLICY.audit.require_signature
+    else None
+)
+_AUDIT_SIGNER = AuditSigner(_AUDIT_SECRET_VALUE)
+
+
+def _refresh_policy() -> None:
+    global _CURRENT_POLICY, _RATE_LIMITER, _AUDIT_SIGNER, _AUDIT_SECRET_VALUE
+    policy = _POLICY_LOADER.load()
+    if (
+        policy.limits.rate_per_minute_global != _CURRENT_POLICY.limits.rate_per_minute_global
+        or policy.limits.rate_per_minute_per_tool != _CURRENT_POLICY.limits.rate_per_minute_per_tool
+    ):
+        _RATE_LIMITER = RateLimiter(
+            RateLimitConfig(
+                per_minute_global=policy.limits.rate_per_minute_global,
+                per_minute_tool=policy.limits.rate_per_minute_per_tool,
+            )
+        )
+    expected_secret = (
+        load_secret_from_env(policy.audit.hmac_secret_env) if policy.audit.require_signature else None
+    )
+    if expected_secret != _AUDIT_SECRET_VALUE:
+        _AUDIT_SECRET_VALUE = expected_secret
+        _AUDIT_SIGNER = AuditSigner(expected_secret)
+    elif not policy.audit.require_signature and _AUDIT_SECRET_VALUE is not None:
+        _AUDIT_SECRET_VALUE = None
+        _AUDIT_SIGNER = AuditSigner(None)
+    _CURRENT_POLICY = policy
+
+
+def _get_policy():
+    _refresh_policy()
+    return _CURRENT_POLICY
+
+
+def _extract_role(ctx: Context, policy) -> str:
+    default_role = "dev"
+    role = default_role
+    session = getattr(ctx, "session", None)
+    if isinstance(session, dict):
+        candidate = session.get("role")
+        if isinstance(candidate, str):
+            role = candidate
+    meta = getattr(ctx, "meta", None)
+    if isinstance(meta, dict):
+        candidate = meta.get("role")
+        if isinstance(candidate, str):
+            role = candidate
+    if role not in policy.roles:
+        return default_role
+    return role
+
+
+def _flatten_paths(value):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _flatten_paths(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _flatten_paths(item)
+
+
+def _iter_paths(params: Dict[str, Any]):
+    for key, value in params.items():
+        key_lower = key.lower()
+        if any(token in key_lower for token in ("path", "dir", "root")):
+            yield from _flatten_paths(value)
+
+
+def _max_array_length(payload: Dict[str, Any]) -> int:
+    max_len = 0
+    stack = [payload]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            stack.extend(current.values())
+        elif isinstance(current, list):
+            max_len = max(max_len, len(current))
+            stack.extend(current)
+    return max_len
+
+
+def _redact_sensitive(value: Any, key: Optional[str] = None) -> Any:
+    sensitive_markers = {"token", "password", "secret", "key"}
+    if isinstance(value, dict):
+        return {k: _redact_sensitive(v, k) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_sensitive(item, key) for item in value]
+    if isinstance(value, str) and (key and any(marker in key.lower() for marker in sensitive_markers)):
+        return "[REDACTED]"
+    if isinstance(value, str) and any(marker in value.lower() for marker in sensitive_markers):
+        return "[REDACTED]"
+    return value
+
+
+def _apply_security(ctx: Context, tool_name: str, params: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    policy = _get_policy()
+    role = _extract_role(ctx, policy)
+    if not policy.is_tool_allowed(role, tool_name):
+        return {
+            "ok": False,
+            "error": {"code": "TOOL_DENIED", "message": "Denied by role/policy", "details": {"role": role}},
+        }
+
+    allowed, retry = _RATE_LIMITER.check(tool_name)
+    if not allowed:
+        return {
+            "ok": False,
+            "error": {
+                "code": "RATE_LIMITED",
+                "message": "Rate limit exceeded",
+                "details": {"retryAfterSec": int(retry) + 1},
+            },
+        }
+
+    serialized = json.dumps(params or {}, separators=(",", ":"), ensure_ascii=False)
+    if len(serialized.encode("utf-8")) > policy.limits.request_size_kb * 1024:
+        return {
+            "ok": False,
+            "error": {"code": "REQUEST_TOO_LARGE", "message": "Request exceeds configured size limit"},
+        }
+
+    if _max_array_length(params) > policy.limits.array_items_max:
+        return {
+            "ok": False,
+            "error": {"code": "ARRAY_TOO_LARGE", "message": "Array exceeds configured item limit"},
+        }
+
+    schema_error = validate_schema(tool_name, params)
+    if schema_error:
+        return {
+            "ok": False,
+            "error": {"code": "INVALID_PARAMS", "message": "Schema validation failed", "details": {"error": schema_error}},
+        }
+
+    for candidate in _iter_paths(params):
+        if isinstance(candidate, str) and candidate:
+            if not is_path_allowed(candidate, policy.paths.allowed, policy.paths.forbidden):
+                return {
+                    "ok": False,
+                    "error": {
+                        "code": "PATH_NOT_ALLOWED",
+                        "message": "Path outside sandbox",
+                        "details": {"path": candidate},
+                    },
+                }
+
+    return None
+
+
+def _finalize_response(tool_name: str, ctx: Context, params: Dict[str, Any], response: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(response, dict):
+        return response
+    policy = _get_policy()
+    result = dict(response)
+    if policy.audit.require_signature and _AUDIT_SIGNER and response.get("ok"):
+        request_id = getattr(ctx, "request_id", None) or getattr(ctx, "requestId", None) or str(uuid.uuid4())
+        audit_payload = {
+            "params": _redact_sensitive(params),
+            "result": _redact_sensitive(response.get("result", {}), "result"),
+            "audit": _redact_sensitive(response.get("audit", {}), "audit"),
+        }
+        signature = _AUDIT_SIGNER.sign(AuditRecord(request_id=request_id, tool=tool_name, payload=audit_payload))
+        if signature:
+            result.setdefault("security", {}).update(signature)
+    return result
 
 
 def register_server_tools(mcp: FastMCP) -> None:
@@ -33,8 +222,11 @@ def register_server_tools(mcp: FastMCP) -> None:
                     "details": {"receivedType": type(params).__name__},
                 },
             }
+        violation = _apply_security(ctx, "uat.buildcookrun", payload)
+        if violation:
+            return violation
 
-        return run_buildcookrun(payload)
+        return _finalize_response("uat.buildcookrun", ctx, payload, run_buildcookrun(payload))
 
     @mcp.tool(name="automation.run_specs")
     def _automation_run_specs(ctx: Context, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -53,8 +245,11 @@ def register_server_tools(mcp: FastMCP) -> None:
                     "details": {"receivedType": type(params).__name__},
                 },
             }
+        violation = _apply_security(ctx, "automation.run_specs", payload)
+        if violation:
+            return violation
 
-        return run_specs(payload)
+        return _finalize_response("automation.run_specs", ctx, payload, run_specs(payload))
 
     @mcp.tool(name="gauntlet.run")
     def _gauntlet_run(ctx: Context, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -73,8 +268,11 @@ def register_server_tools(mcp: FastMCP) -> None:
                     "details": {"receivedType": type(params).__name__},
                 },
             }
+        violation = _apply_security(ctx, "gauntlet.run", payload)
+        if violation:
+            return violation
 
-        return run_gauntlet(payload)
+        return _finalize_response("gauntlet.run", ctx, payload, run_gauntlet(payload))
 
     @mcp.tool(name="mcp.health")
     def _mcp_health(ctx: Context, params: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add security helper modules for policies, rate limiting, sandbox normalization, and audit signatures
- enforce RBAC, request limits, path sandboxing, and signed audit responses in Python server tools
- document security configuration updates, add example secrets file, and include jsonschema/pyyaml dependencies

## Testing
- python -m compileall Python/security Python/server.py

------
https://chatgpt.com/codex/tasks/task_e_68dbca2e8e24832fb0d51d9e39f7bc2a