### PR TITLE
chore(metasound): add placeholder metasound routes

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/MetaSounds/MetaSoundTools.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/MetaSounds/MetaSoundTools.cpp
@@ -1,0 +1,49 @@
+#include "MetaSounds/MetaSoundTools.h"
+
+#include "Dom/JsonObject.h"
+
+namespace
+{
+        constexpr const TCHAR* ErrorCodeNotImplemented = TEXT("NOT_IMPLEMENTED");
+
+        TSharedPtr<FJsonObject> MakeNotImplementedResponse(const FString& Command)
+        {
+                TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+                Result->SetBoolField(TEXT("ok"), false);
+                Result->SetBoolField(TEXT("success"), false);
+                Result->SetStringField(TEXT("errorCode"), ErrorCodeNotImplemented);
+                Result->SetStringField(TEXT("error"), FString::Printf(TEXT("MetaSound command '%s' is not implemented yet."), *Command));
+                return Result;
+        }
+}
+
+TSharedPtr<FJsonObject> FMetaSoundTools::SpawnComponent(const TSharedPtr<FJsonObject>& /*Params*/)
+{
+        return MakeNotImplementedResponse(TEXT("metasound.spawn_component"));
+}
+
+TSharedPtr<FJsonObject> FMetaSoundTools::SetParameters(const TSharedPtr<FJsonObject>& /*Params*/)
+{
+        return MakeNotImplementedResponse(TEXT("metasound.set_params"));
+}
+
+TSharedPtr<FJsonObject> FMetaSoundTools::Play(const TSharedPtr<FJsonObject>& /*Params*/)
+{
+        return MakeNotImplementedResponse(TEXT("metasound.play"));
+}
+
+TSharedPtr<FJsonObject> FMetaSoundTools::Stop(const TSharedPtr<FJsonObject>& /*Params*/)
+{
+        return MakeNotImplementedResponse(TEXT("metasound.stop"));
+}
+
+TSharedPtr<FJsonObject> FMetaSoundTools::ExportInfo(const TSharedPtr<FJsonObject>& /*Params*/)
+{
+        return MakeNotImplementedResponse(TEXT("metasound.export_info"));
+}
+
+TSharedPtr<FJsonObject> FMetaSoundTools::PatchPreset(const TSharedPtr<FJsonObject>& /*Params*/)
+{
+        return MakeNotImplementedResponse(TEXT("metasound.patch_preset"));
+}
+

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPBridge.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPBridge.cpp
@@ -62,6 +62,7 @@
 #include "Assets/AssetImport.h"
 #include "Assets/AssetQuery.h"
 #include "Niagara/NiagaraTools.h"
+#include "MetaSounds/MetaSoundTools.h"
 #include "Actors/ActorTools.h"
 #include "EditorNav/EditorNavTools.h"
 #include "Levels/LevelTools.h"
@@ -794,6 +795,30 @@ FString UUnrealMCPBridge::ExecuteCommand(const FString& CommandType, const TShar
                 else if (CommandType == TEXT("niagara.deactivate"))
                 {
                     ResultJson = FNiagaraTools::Deactivate(Params);
+                }
+                else if (CommandType == TEXT("metasound.spawn_component"))
+                {
+                    ResultJson = FMetaSoundTools::SpawnComponent(Params);
+                }
+                else if (CommandType == TEXT("metasound.set_params"))
+                {
+                    ResultJson = FMetaSoundTools::SetParameters(Params);
+                }
+                else if (CommandType == TEXT("metasound.play"))
+                {
+                    ResultJson = FMetaSoundTools::Play(Params);
+                }
+                else if (CommandType == TEXT("metasound.stop"))
+                {
+                    ResultJson = FMetaSoundTools::Stop(Params);
+                }
+                else if (CommandType == TEXT("metasound.export_info"))
+                {
+                    ResultJson = FMetaSoundTools::ExportInfo(Params);
+                }
+                else if (CommandType == TEXT("metasound.patch_preset"))
+                {
+                    ResultJson = FMetaSoundTools::PatchPreset(Params);
                 }
                 else if (CommandType == TEXT("asset.fix_redirectors"))
                 {

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/MetaSounds/MetaSoundTools.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/MetaSounds/MetaSoundTools.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FJsonObject;
+
+/** Placeholder MetaSound helpers exposed through the MCP bridge. */
+class UNREALMCP_API FMetaSoundTools
+{
+public:
+        /** Spawn a MetaSound-backed audio component (currently not implemented). */
+        static TSharedPtr<FJsonObject> SpawnComponent(const TSharedPtr<FJsonObject>& Params);
+
+        /** Set parameters on an AudioComponent that plays a MetaSound (currently not implemented). */
+        static TSharedPtr<FJsonObject> SetParameters(const TSharedPtr<FJsonObject>& Params);
+
+        /** Start playback on an AudioComponent (currently not implemented). */
+        static TSharedPtr<FJsonObject> Play(const TSharedPtr<FJsonObject>& Params);
+
+        /** Stop playback on an AudioComponent (currently not implemented). */
+        static TSharedPtr<FJsonObject> Stop(const TSharedPtr<FJsonObject>& Params);
+
+        /** Export information about a MetaSound source (currently not implemented). */
+        static TSharedPtr<FJsonObject> ExportInfo(const TSharedPtr<FJsonObject>& Params);
+
+        /** Create or update a MetaSound preset asset (currently not implemented). */
+        static TSharedPtr<FJsonObject> PatchPreset(const TSharedPtr<FJsonObject>& Params);
+};
+

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
@@ -56,6 +56,8 @@ public class UnrealMCP : ModuleRules
                                 "Projects",
                                 "AssetRegistry",
                                 "AssetTools",
+                                "AudioMixer",
+                                "SignalProcessing",
                                 "RenderingCommon",
                                 "SkeletalMeshUtilitiesCommon",
                                 "SourceControl",

--- a/Python/README.md
+++ b/Python/README.md
@@ -90,6 +90,8 @@ Le serveur relaie les **tools** vers le plugin UE. Quelques exemples actuels :
   *(création/overrides de MI, assignation scène en masse, remap de slots StaticMesh ; `mi.batch_apply` modifie les maps ouvertes, `mesh.remap_material_slots` agit sur un asset)*
 * Niagara (Editor) : `niagara.spawn_component`, `niagara.set_user_params`, `niagara.activate`, `niagara.deactivate`
   *(mutations scène côté Éditeur/PIE — pas d’édition structurelle des systèmes Niagara)*
+* MetaSounds (préversion) : `metasound.spawn_component`, `metasound.set_params`, `metasound.play`, `metasound.stop`, `metasound.export_info`, `metasound.patch_preset`, `metasound.render_offline`
+  *(routes déclarées côté serveur/éditeur mais actuellement stubs renvoyant `NOT_IMPLEMENTED`)*
 * Navigation éditeur : `level.select`, `viewport.focus`, `camera.bookmark` (`persist=true` pour `set` ⇒ mutation, sinon lecture)
 
 > `asset.batch_import` peut prendre plusieurs secondes (import FBX + textures). La réponse contient le détail par fichier (`created/skipped/overwritten`, warnings, audit).
@@ -126,6 +128,10 @@ Le serveur relaie les **tools** vers le plugin UE. Quelques exemples actuels :
 ```
 
 `dryRun=true` renvoie uniquement la commande et les dossiers touchés, sans lancer RunUAT.
+
+## MetaSounds (préversion)
+
+Les routes MetaSound sont déjà enregistrées côté serveur (`metasound.*`, `metasound.render_offline`) mais renvoient pour l’instant `NOT_IMPLEMENTED`. Elles servent de point d’extension pour une future intégration (UnrealEditor-Cmd + Submix Recorder). La structure de payload suivra le cahier des charges défini dans la roadmap (sourcePath, params, durée, sampleRate, etc.).
 
 ## CLI locale (`mcp`)
 

--- a/Python/metasound_render.py
+++ b/Python/metasound_render.py
@@ -1,0 +1,25 @@
+"""Placeholder implementation for MetaSound offline rendering."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class MetaSoundRenderError(RuntimeError):
+    """Raised when offline rendering is not available."""
+
+
+def run(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Entry point for metasound.render_offline (not implemented)."""
+
+    return {
+        "ok": False,
+        "error": {
+            "code": "NOT_IMPLEMENTED",
+            "message": "metasound.render_offline is not available in this build.",
+        },
+    }
+
+
+__all__ = ["run", "MetaSoundRenderError"]
+

--- a/Python/server.py
+++ b/Python/server.py
@@ -13,6 +13,7 @@ from mcp.server.fastmcp import Context, FastMCP
 
 from automation_specs import run_specs
 from gauntlet import run_gauntlet
+from metasound_render import run as run_metasound_render
 from uat import run_buildcookrun
 from security.audit_sign import AuditRecord, AuditSigner, load_secret_from_env
 from security.policy import PolicyLoader
@@ -250,6 +251,35 @@ def register_server_tools(mcp: FastMCP) -> None:
             return violation
 
         return _finalize_response("automation.run_specs", ctx, payload, run_specs(payload))
+
+    @mcp.tool(name="metasound.render_offline")
+    def _metasound_render_offline(ctx: Context, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Offline render a MetaSound via UnrealEditor-Cmd."""
+
+        if params is None:
+            payload = {}
+        elif isinstance(params, dict):
+            payload = params
+        else:
+            return {
+                "ok": False,
+                "error": {
+                    "code": "INVALID_PARAMS",
+                    "message": "Expected params to be an object for metasound.render_offline.",
+                    "details": {"receivedType": type(params).__name__},
+                },
+            }
+
+        violation = _apply_security(ctx, "metasound.render_offline", payload)
+        if violation:
+            return violation
+
+        return _finalize_response(
+            "metasound.render_offline",
+            ctx,
+            payload,
+            run_metasound_render(payload),
+        )
 
     @mcp.tool(name="gauntlet.run")
     def _gauntlet_run(ctx: Context, params: Dict[str, Any]) -> Dict[str, Any]:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - **Sequencer v1** : `sequence.create` pour générer un Level Sequence (fps, durée, évaluation, caméra/camera-cut/bind optionnels).
 - **Materials v1 (Material Instances)** : `mi.create` et `mi.set_params` pour créer des MI et régler leurs overrides.
 - **Niagara v1 (Editor)** : `niagara.spawn_component / niagara.set_user_params / niagara.activate / niagara.deactivate`.
+- **MetaSounds (preview)** : routes `metasound.*` et `metasound.render_offline` déclarées (retournent actuellement `NOT_IMPLEMENTED`).
 - **Actors v1 (Editor)** : `actor.spawn / actor.destroy / actor.attach / actor.transform / actor.tag` (transactions, sélection, audit).
 - **Camera helpers (Editor)** : `level.select / viewport.focus / camera.bookmark` (navigation + bookmarks, session & persistance).
 - **Build & Test v2** : wrappers RunUAT `BuildCookRun`, `automation.run_specs` (Editor-Cmd) et `gauntlet.run` (cooked) avec logs persistants & parsing basique.
@@ -206,6 +207,21 @@ Fonctionnalités transverses : `--dry-run`, `--retry`, `--parallel`, `--vars`/`-
   "save": true
 }
 ```
+
+### MetaSounds (préversion)
+
+> ⚠️ Les routes sont exposées mais renvoient pour l’instant `NOT_IMPLEMENTED`. Elles servent de squelette en attendant l’intégration complète côté éditeur et serveur.
+
+| Tool                        | Type      | Description                                                |
+|-----------------------------|-----------|------------------------------------------------------------|
+| `metasound.spawn_component` | mutation  | Devrait instancier un `UAudioComponent` MetaSound (stub)   |
+| `metasound.set_params`      | mutation  | Devrait appliquer des paramètres exposés (stub)            |
+| `metasound.play` / `stop`   | mutation  | Devrait lancer/arrêter la lecture avec fondu (stub)        |
+| `metasound.export_info`     | read-only | Devrait retourner la liste des paramètres exposés (stub)   |
+| `metasound.patch_preset`    | mutation  | Devrait créer/mettre à jour un preset MetaSound (stub)     |
+| `metasound.render_offline`  | external  | Devrait lancer UnrealEditor-Cmd pour générer un WAV (stub) |
+
+Des exemples de payloads et le cahier des charges complet sont consignés dans la demande de fonctionnalités correspondante (voir historique du projet).
 
 #### Materials
 


### PR DESCRIPTION
## Summary
- scaffold MetaSound tool entry points in the Unreal bridge that currently return NOT_IMPLEMENTED
- expose the metasound.render_offline Python tool stub and update documentation to reflect the preview status
- update build dependencies and READMEs to signal the forthcoming MetaSound work

## Testing
- not run (documentation-only scaffolding)


------
https://chatgpt.com/codex/tasks/task_e_68dbd140b778832f94aa7c0e6affd852