### PR TITLE
chore(plugin): validate UnrealMCP.uplugin for UE5.6 (Editor-only, versions, modules)

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/UnrealMCP.uplugin
+++ b/MCPGameProject/Plugins/UnrealMCP/UnrealMCP.uplugin
@@ -1,35 +1,36 @@
 {
-	"FileVersion": 3,
-	"Version": 1,
-	"VersionName": "1.0",
-	"FriendlyName": "UnrealMCP",
-	"Description": "Model Context Protocol implementation for Unreal Engine",
-	"Category": "Editor",
-	"CreatedBy": "Your Name",
-	"CreatedByURL": "",
-	"DocsURL": "",
-	"MarketplaceURL": "",
-	"SupportURL": "",
-	"CanContainContent": true,
-	"IsBetaVersion": false,
-	"IsExperimentalVersion": false,
-	"Installed": false,
-	"Modules": [
-		{
-			"Name": "UnrealMCP",
-			"Type": "Editor",
-			"LoadingPhase": "Default",
-			"WhitelistPlatforms": [
-				"Win64",
-				"Mac",
-				"Linux"
-			]
-		}
-	],
-	"Plugins": [
-		{
-			"Name": "EditorScriptingUtilities",
-			"Enabled": true
-		}
-	]
-} 
+    "FileVersion": 3,
+    "Version": 2,
+    "VersionName": "0.2.0",
+    "FriendlyName": "Unreal MCP",
+    "Description": "Model Context Protocol bridge and editor tooling for Unreal Engine.",
+    "Category": "Developer Tools",
+    "CreatedBy": "Your Name",
+    "CreatedByURL": "",
+    "DocsURL": "",
+    "MarketplaceURL": "",
+    "SupportURL": "",
+    "EnabledByDefault": false,
+    "CanContainContent": false,
+    "IsBetaVersion": false,
+    "IsExperimentalVersion": false,
+    "Installed": false,
+    "Modules": [
+        {
+            "Name": "UnrealMCP",
+            "Type": "Editor",
+            "LoadingPhase": "Default"
+        }
+    ],
+    "Plugins": [
+        {
+            "Name": "EditorScriptingUtilities",
+            "Enabled": true
+        }
+    ],
+    "EngineVersionRange": [
+        {
+            "Min": "5.6.0"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- update the UnrealMCP plugin descriptor for Unreal Engine 5.6 editor usage
- ensure the module is marked as editor-only and remove runtime platform claims
- refresh version metadata and add an engine version range compatible with UE 5.6

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e382a8cfcc832f8ade31050e641000