### PR TITLE
fix(ue5.6): align includes and APIs for UE5.6 build

### DIFF
--- a/_package/UnrealMCP_Win64/HostProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintCommands.cpp
+++ b/_package/UnrealMCP_Win64/HostProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintCommands.cpp
@@ -213,26 +213,26 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintCommands::HandleAddComponentToBluepri
     UClass* ComponentClass = nullptr;
 
     // Try to find the class with exact name first
-    ComponentClass = FindObject<UClass>(ANY_PACKAGE, *ComponentType);
+    ComponentClass = FindObject<UClass>(nullptr, *ComponentType);
     
     // If not found, try with "Component" suffix
     if (!ComponentClass && !ComponentType.EndsWith(TEXT("Component")))
     {
         FString ComponentTypeWithSuffix = ComponentType + TEXT("Component");
-        ComponentClass = FindObject<UClass>(ANY_PACKAGE, *ComponentTypeWithSuffix);
+        ComponentClass = FindObject<UClass>(nullptr, *ComponentTypeWithSuffix);
     }
     
     // If still not found, try with "U" prefix
     if (!ComponentClass && !ComponentType.StartsWith(TEXT("U")))
     {
         FString ComponentTypeWithPrefix = TEXT("U") + ComponentType;
-        ComponentClass = FindObject<UClass>(ANY_PACKAGE, *ComponentTypeWithPrefix);
+        ComponentClass = FindObject<UClass>(nullptr, *ComponentTypeWithPrefix);
         
         // Try with both prefix and suffix
         if (!ComponentClass && !ComponentType.EndsWith(TEXT("Component")))
         {
             FString ComponentTypeWithBoth = TEXT("U") + ComponentType + TEXT("Component");
-            ComponentClass = FindObject<UClass>(ANY_PACKAGE, *ComponentTypeWithBoth);
+            ComponentClass = FindObject<UClass>(nullptr, *ComponentTypeWithBoth);
         }
     }
     

--- a/_package/UnrealMCP_Win64/HostProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintNodeCommands.cpp
+++ b/_package/UnrealMCP_Win64/HostProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintNodeCommands.cpp
@@ -318,7 +318,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
         UClass* TargetClass = nullptr;
         
         // First try without a prefix
-        TargetClass = FindObject<UClass>(ANY_PACKAGE, *Target);
+        TargetClass = FindObject<UClass>(nullptr, *Target);
         UE_LOG(LogTemp, Display, TEXT("Tried to find class '%s': %s"), 
                *Target, TargetClass ? TEXT("Found") : TEXT("Not found"));
         
@@ -326,7 +326,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
         if (!TargetClass && !Target.StartsWith(TEXT("U")))
         {
             FString TargetWithPrefix = FString(TEXT("U")) + Target;
-            TargetClass = FindObject<UClass>(ANY_PACKAGE, *TargetWithPrefix);
+            TargetClass = FindObject<UClass>(nullptr, *TargetWithPrefix);
             UE_LOG(LogTemp, Display, TEXT("Tried to find class '%s': %s"), 
                    *TargetWithPrefix, TargetClass ? TEXT("Found") : TEXT("Not found"));
         }
@@ -341,7 +341,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
             
             for (const FString& ClassName : PossibleClassNames)
             {
-                TargetClass = FindObject<UClass>(ANY_PACKAGE, *ClassName);
+                TargetClass = FindObject<UClass>(nullptr, *ClassName);
                 if (TargetClass)
                 {
                     UE_LOG(LogTemp, Display, TEXT("Found class using alternative name '%s'"), *ClassName);
@@ -354,7 +354,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
         if (!TargetClass && Target == TEXT("UGameplayStatics"))
         {
             // For UGameplayStatics, use a direct reference to known class
-            TargetClass = FindObject<UClass>(ANY_PACKAGE, TEXT("UGameplayStatics"));
+            TargetClass = FindObject<UClass>(nullptr, TEXT("UGameplayStatics"));
             if (!TargetClass)
             {
                 // Try loading it from its known package
@@ -501,7 +501,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
                             const FString& ClassName = StringVal;
                             
                             // TODO: This likely won't work in UE5.5+, so don't rely on it.
-                            UClass* Class = FindObject<UClass>(ANY_PACKAGE, *ClassName);
+                            UClass* Class = FindObject<UClass>(nullptr, *ClassName);
 
                             if (!Class)
                             {

--- a/_package/UnrealMCP_Win64/HostProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
+++ b/_package/UnrealMCP_Win64/HostProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
@@ -585,7 +585,7 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleTakeScreenshot(const TSh
         if (Viewport->ReadPixels(Bitmap, FReadSurfaceDataFlags(), ViewportRect))
         {
             TArray<uint8> CompressedBitmap;
-            FImageUtils::CompressImageArray(Viewport->GetSizeXY().X, Viewport->GetSizeXY().Y, Bitmap, CompressedBitmap);
+            FImageUtils::PNGCompressImageArray(Viewport->GetSizeXY().X, Viewport->GetSizeXY().Y, Bitmap, CompressedBitmap);
             
             if (FFileHelper::SaveArrayToFile(CompressedBitmap, *FilePath))
             {

--- a/_package/UnrealMCP_Win64/HostProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPUMGCommands.cpp
+++ b/_package/UnrealMCP_Win64/HostProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPUMGCommands.cpp
@@ -5,7 +5,7 @@
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "Blueprint/UserWidget.h"
 #include "Components/TextBlock.h"
-#include "WidgetBlueprint.h"
+#include "Blueprint/WidgetBlueprint.h"
 // We'll create widgets using regular Factory classes
 #include "Factories/Factory.h"
 // Remove problematic includes that don't exist in UE 5.5

--- a/_package/UnrealMCP_Win64/HostProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Sequencer/SequenceTools.cpp
+++ b/_package/UnrealMCP_Win64/HostProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Sequencer/SequenceTools.cpp
@@ -24,6 +24,7 @@
 #include "SourceControlService.h"
 #include "Tracks/MovieSceneCameraCutTrack.h"
 #include "UObject/Package.h"
+#include "UObject/SoftObjectPath.h"
 #include "UObject/UObjectGlobals.h"
 
 namespace
@@ -384,7 +385,8 @@ TSharedPtr<FJsonObject> FSequenceTools::Create(const TSharedPtr<FJsonObject>& Pa
     Params->TryGetStringField(TEXT("cameraName"), CameraName);
 
     IAssetRegistry& AssetRegistry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry")).Get();
-    const FAssetData ExistingAsset = AssetRegistry.GetAssetByObjectPath(FName(*ObjectPath));
+    const FSoftObjectPath SequenceSoftPath(ObjectPath);
+    const FAssetData ExistingAsset = AssetRegistry.GetAssetByObjectPath(SequenceSoftPath, /*bIncludeOnlyOnDiskAssets*/ false, /*bSkipARFilteredAssets*/ false);
     const bool bAssetExists = ExistingAsset.IsValid();
 
     if (bAssetExists && !bOverwriteIfExists)

--- a/_package/UnrealMCP_Win64/HostProject/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
+++ b/_package/UnrealMCP_Win64/HostProject/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
@@ -35,43 +35,47 @@ public class UnrealMCP : ModuleRules
                 "InputCore",
                 "Json",
                 "JsonUtilities",
+                "AssetRegistry",
+                "Sockets",
                 "Networking",
                 "RenderCore",
                 "RHI",
-                "Sockets"
+                "LevelSequence",
+                "UMG"
             }
         );
 
         PrivateDependencyModuleNames.AddRange(
             new string[]
             {
-                "AssetRegistry",
+                "UnrealEd",
+                "LevelEditor",
+                "PropertyEditor",
                 "AssetTools",
+                "EditorScriptingUtilities",
+                "Blutility",
+                "Slate",
+                "SlateCore",
+                "Sequencer",
+                "MovieScene",
+                "SequencerScripting",
+                "LevelSequenceEditor",
+                "UMGEditor",
+                "Niagara",
+                "NiagaraCore",
                 "AudioMixer",
                 "BlueprintGraph",
-                "Blutility",
                 "CinematicCamera",
-                "EditorScriptingUtilities",
                 "EditorSubsystem",
                 "Kismet",
                 "KismetCompiler",
-                "LevelEditor",
-                "LevelSequence",
-                "MovieScene",
                 "MovieSceneTools",
                 "MovieSceneTracks",
-                "Niagara",
-                "NiagaraCore",
                 "Projects",
-                "SequencerScripting",
                 "Settings",
                 "SignalProcessing",
                 "SkeletalMeshUtilitiesCommon",
-                "Slate",
-                "SlateCore",
-                "SourceControl",
-                "UMG",
-                "UnrealEd"
+                "SourceControl"
             }
         );
 
@@ -81,9 +85,7 @@ public class UnrealMCP : ModuleRules
                 new string[]
                 {
                     "BlueprintEditorLibrary", // For Blueprint utilities
-                    "PropertyEditor",         // For widget property editing
-                    "ToolMenus",             // For editor UI
-                    "UMGEditor"               // For WidgetBlueprint.h and other UMG editor functionality
+                    "ToolMenus"              // For editor UI
                 }
             );
         }


### PR DESCRIPTION
## Summary
- expand module dependencies so LevelSequence/UMG editor types are available at build time
- refresh asset import, query, and content tools to use UE 5.6 headers and AssetRegistry APIs
- modernize command utilities for UE 5.6 (UMG includes, screenshot compression, class lookup helpers)

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e513d75928832fa4a5e5eb545234b2